### PR TITLE
Removed branch tag on GPD package and specified branch on Xarm package in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,8 @@
 [submodule "manipulation/packages/gpd"]
 	path = manipulation/packages/gpd
 	url = https://github.com/Deivideich/gpd
-	branch = humble
 	
 [submodule "manipulation/packages/xarm_ros2"]
 	path = manipulation/packages/xarm_ros2
 	url = https://github.com/xArm-Developer/xarm_ros2.git
+	branch = humble


### PR DESCRIPTION
GPD package doesnt need a specified branch, it causes a crash when doing the cloning process

Instead, the Xarm ROS2 pkg needs its branch to be specified at humble, otherwise the colcon build process will fail