### PR TITLE
Local ollama containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 **.pt
 **.pth
 **.gz
+hri/packages/nlp/assets/**
+!hri/packages/nlp/assets/download-model.bash

--- a/docker/hri/docker-compose.yml
+++ b/docker/hri/docker-compose.yml
@@ -2,6 +2,7 @@ include:
   # Jetson Orin
   - path: l4t-devices.yaml
   - path: stt-l4t.yaml
+  - path: ollama-jetson.yaml
   # - path: chromadb.yaml
 
   # Laptop

--- a/docker/hri/ollama-jetson.yaml
+++ b/docker/hri/ollama-jetson.yaml
@@ -1,0 +1,13 @@
+services:
+  ollama:
+    container_name: home2-hri-ollama
+    image: dustynv/ollama:r36.4.0
+    runtime: nvidia
+    network_mode: host
+    volumes:
+      - ../../hri/packages/nlp/assets:/ollama
+    environment:
+      - OLLAMA_MODELS=/ollama
+    stdin_open: true
+    tty: true
+    restart: unless-stopped

--- a/docker/hri/ollama.yaml
+++ b/docker/hri/ollama.yaml
@@ -1,0 +1,13 @@
+services:
+  ollama:
+    container_name: home2-hri-ollama
+    image: ollama/ollama
+    runtime: nvidia
+    network_mode: host
+    volumes:
+      - ../../hri/packages/nlp/assets:/ollama
+    environment:
+      - OLLAMA_MODELS=/ollama
+    stdin_open: true
+    tty: true
+    restart: unless-stopped

--- a/hri/packages/nlp/assets/download-model.bash
+++ b/hri/packages/nlp/assets/download-model.bash
@@ -1,0 +1,2 @@
+curl -L https://huggingface.co/diegohc/robollm/resolve/main/rbrgs-finetuned-unsloth.F16.gguf -o rbrgs-finetuned.F16.gguf
+curl -L https://huggingface.co/diegohc/robollm/resolve/main/Modelfile -o Modelfile


### PR DESCRIPTION
Adds docker compose files to run ollama on jetson and computers. Also adds script to download model files from huggingface, and updates gitignore to ignore them

Resolves #60 