### PR TITLE
Octomap working in real arm

### DIFF
--- a/manipulation/packages/arm_pkg/config/sensors_3d.yaml
+++ b/manipulation/packages/arm_pkg/config/sensors_3d.yaml
@@ -3,7 +3,7 @@ sensors:
 
 point_cloud_camera:
     sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
-    point_cloud_topic: /depth/color/points
+    point_cloud_topic: /zed/zed_node/point_cloud/cloud_registered
     max_range: 2.0
     point_subsample: 1
     padding_offset: 0.1

--- a/manipulation/packages/arm_pkg/launch/frida_moveit_common.launch.py
+++ b/manipulation/packages/arm_pkg/launch/frida_moveit_common.launch.py
@@ -69,8 +69,8 @@ def launch_setup(context, *args, **kwargs):
     moveit_config_package_name = "xarm_moveit_config"
 
     octomap_config = {
-        "octomap_frame": "base",
-        "octomap_resolution": 0.01,
+        "octomap_frame": "base_link",
+        "octomap_resolution": 0.05,
         "max_range": 2.0,
     }
 

--- a/manipulation/packages/arm_pkg/launch/frida_moveit_config.launch.py
+++ b/manipulation/packages/arm_pkg/launch/frida_moveit_config.launch.py
@@ -157,9 +157,9 @@ def launch_setup(context, *args, **kwargs):
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(
                 [
-                    FindPackageShare("xarm_moveit_config"),
+                    FindPackageShare("arm_pkg"),
                     "launch",
-                    "_robot_moveit_common2.launch.py",
+                    "frida_moveit_common.launch.py",
                 ]
             )
         ),


### PR DESCRIPTION
Now it is possible to launch the real arm with the octomap using the Moveit's built in Octomap Plugin for OA

The main change was the addition of the .yaml with the plugin description, and the octomap yaml loader inside the move_group node, as seen in frida_moveit_common.launch

use: ros2 launch arm_pkg frida_moveit_config.launch.py 

and ros2 launch zed_wrapper zed_camera.launch.py camera_model:=zed2 publish_tf:=false

configure the octomap resultion in the move_group and node and its own .yaml inside config folder