### PR TITLE
Temporary workaround to avoid the robot moving by itself when is stationary in the gazebo simulation

### DIFF
--- a/robot_description/frida_description/urdf/base.xacro
+++ b/robot_description/frida_description/urdf/base.xacro
@@ -4,7 +4,7 @@
   <link name="base_link">
     <inertial>
       <origin xyz="-0.017897 -0.0059216 0.12557" rpy="0 0 0" />
-      <mass value="31.075" />
+      <mass value="131.075" />
       <inertia ixx="0.67537" ixy="-0.00030935" ixz="-0.0025852"
                iyy="0.61552" iyz="-0.0003748" izz="0.65918" />
     </inertial>

--- a/robot_description/frida_description/urdf/gazebo.xacro
+++ b/robot_description/frida_description/urdf/gazebo.xacro
@@ -71,13 +71,13 @@
     </gazebo>
 
 <gazebo reference="caster_wheel_right">
-      <mu1 value="0.001"/>
-      <mu2 value="0.001"/>
+      <mu1 value="0.1"/>
+      <mu2 value="0.1"/>
     <material>Gazebo/Black</material>
   </gazebo>
   <gazebo reference="caster_wheel_left">
-      <mu1 value="0.001"/>
-      <mu2 value="0.001"/>
+      <mu1 value="0.1"/>
+      <mu2 value="0.1"/>
     <material>Gazebo/Black</material>
   </gazebo>
    <gazebo reference="base_link">

--- a/robot_description/frida_description/urdf/wheels.xacro
+++ b/robot_description/frida_description/urdf/wheels.xacro
@@ -5,7 +5,7 @@
     <link name="${prefix}_wheel">
       <inertial>
         <origin xyz="-1.3878E-17 0 2.7756E-17" rpy="0 0 0" />
-        <mass value="0.52892" />
+        <mass value="100.52892" />
         <inertia ixx="0.00063131" ixy="${ixy}" ixz="${ixz}"
                  iyy="0.00063131" iyz="${iyz}" izz="0.0011216" />
       </inertial>


### PR DESCRIPTION
Temporary change of wheel's weight from 0.5 kgs to 100 kgs so the robot wont move when stationary. Further research is required to have a more realistic performance