### PR TITLE
Rviz laser /scan filter fix

### DIFF
--- a/navigation/packages/nav_main/src/ignore_laser.cpp
+++ b/navigation/packages/nav_main/src/ignore_laser.cpp
@@ -41,7 +41,7 @@ private:
     void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr scan)
     {
         auto new_scan = *scan;
-        int count = static_cast<int>(scan->scan_time / scan->time_increment);
+        int count = static_cast<int>(ceil((scan->angle_max - scan->angle_min) / scan->time_increment));
 
         for (int i = 0; i < count; ++i) {
             float degree = RAD2DEG(scan->angle_min + scan->angle_increment * i);

--- a/navigation/packages/nav_main/src/ignore_laser.cpp
+++ b/navigation/packages/nav_main/src/ignore_laser.cpp
@@ -41,7 +41,7 @@ private:
     void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr scan)
     {
         auto new_scan = *scan;
-        int count = static_cast<int>(ceil((scan->angle_max - scan->angle_min) / scan->time_increment));
+        int count = static_cast<int>(ceil((scan->angle_max - scan->angle_min) / scan->angle_increment));
 
         for (int i = 0; i < count; ++i) {
             float degree = RAD2DEG(scan->angle_min + scan->angle_increment * i);


### PR DESCRIPTION
La información del scan no era filtrada con los ángulos de rplidar_fixed.launch.py por un detalle en la linea 44:

        int count = static_cast<int>(scan->scan_time / scan->time_increment);

Aparentemente en el plugin que generaba el mensaje del lidar en /scan_input ponía siempre **scan_time** y **time_increment** como 0.0, por lo que el **count** siempre era cero, no entraba al ciclo for y no filtraba

Cambiando la linea 44 por lo siguiente lo arregla, hace lo mismo, pero usa los angulos maximo y minimo y el angle_increment para calcular el número de mediciones por revolución:

int count = static_cast<int>(ceil((scan->angle_max - scan->angle_min) / scan->time_increment));


referencia: https://github.com/ros-simulation/gazebo_ros_pkgs/issues/834 