### PR TITLE
add layer for caching frida interfaces and constants

### DIFF
--- a/docker/frida_interfaces_cache/cpu.yaml
+++ b/docker/frida_interfaces_cache/cpu.yaml
@@ -6,7 +6,7 @@ services:
       dockerfile: ../Dockerfile.ROS
       args:
         BASE_IMAGE: ubuntu:22.04
-    image: roborregos/home2:l4t_base
+    image: roborregos/home2:cpu_base
 
     container_name: home2-frida-interfaces-cache
     volumes:

--- a/docker/frida_interfaces_cache/docker-compose.yaml
+++ b/docker/frida_interfaces_cache/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  frida_interfaces_cache:
+    build:
+      context: .
+      # Dockerfile.ROS is the same for both CPU and GPU
+      dockerfile: Dockerfile.ROS
+      args:
+        BASE_IMAGE: ubuntu:22.04
+    image: roborregos/home2:cpu_base
+
+    container_name: home2-frida-interfaces-cache
+    volumes:
+      - ../../:/workspace/src
+      - ./build:/workspace/build
+      - ./install:/workspace/install
+      - ./log:/workspace/log
+    tty: true
+    entrypoint: ["bash", "-il", "-c"]
+    # command: ["bash"]
+    command: ["source /opt/ros/humble/setup.bash && colcon build --packages-select frida_interfaces frida_constants"]

--- a/docker/integration/docker-compose.yaml
+++ b/docker/integration/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
       - ./build:/workspace/build
       - ./install:/workspace/install
       - ./log:/workspace/log
+      - ../frida_interfaces_cache:/workspace/frida_interfaces_cache
     network_mode: host
     user: 1000:1000
     privileged: true

--- a/docker/integration/run.sh
+++ b/docker/integration/run.sh
@@ -141,9 +141,10 @@ fi
 
 # Commands to run inside the container
 SOURCE_ROS="source /opt/ros/humble/setup.bash"
-COLCON="colcon build --packages-up-to "
+SOURCE_INTERFACES="source frida_interfaces_cache/install/local_setup.bash"
+COLCON="colcon build --packages-ignore frida_interfaces frida_constants --packages-up-to "
 SOURCE="source install/setup.bash"
-SETUP="$SOURCE_ROS && $COLCON task_manager && $SOURCE"
+SETUP="$SOURCE_ROS && $SOURCE_INTERFACES && $COLCON task_manager && $SOURCE"
 RUN=""
 MOONDREAM=false
 


### PR DESCRIPTION
add docker compose for building frida_interfaces and frida_constants, and update integration docker setup to use the new layer.

To use, run `docker compose up` to build `frida_interfaces` and `frida_constants`. The resulting files will be automatically used in the integration container. The other docker setups will also be updated to support this cache in the future.