### PR TITLE
Update to not load pretrained swin model

### DIFF
--- a/vision/packages/vision_general/vision_general/utils/models/swin/model.py
+++ b/vision/packages/vision_general/vision_general/utils/models/swin/model.py
@@ -135,7 +135,9 @@ class ft_net_swin(nn.Module):
     def __init__(self, class_num, droprate=0.5, stride=2, circle=False, linear_num=512):
         super(ft_net_swin, self).__init__()
         model_ft = timm.create_model(
-            "swin_base_patch4_window7_224", pretrained=True, drop_path_rate=0.2
+            "swin_base_patch4_window7_224", 
+            pretrained=False, 
+            drop_path_rate=0.2
         )
         # avg pooling to global pooling
         # model_ft.avgpool = nn.AdaptiveAvgPool2d((1,1))

--- a/vision/packages/vision_general/vision_general/utils/models/swin/model.py
+++ b/vision/packages/vision_general/vision_general/utils/models/swin/model.py
@@ -135,9 +135,7 @@ class ft_net_swin(nn.Module):
     def __init__(self, class_num, droprate=0.5, stride=2, circle=False, linear_num=512):
         super(ft_net_swin, self).__init__()
         model_ft = timm.create_model(
-            "swin_base_patch4_window7_224", 
-            pretrained=False, 
-            drop_path_rate=0.2
+            "swin_base_patch4_window7_224", pretrained=False, drop_path_rate=0.2
         )
         # avg pooling to global pooling
         # model_ft.avgpool = nn.AdaptiveAvgPool2d((1,1))

--- a/vision/packages/vision_general/vision_general/utils/reid_model.py
+++ b/vision/packages/vision_general/vision_general/utils/reid_model.py
@@ -18,7 +18,6 @@ epoch = "last"
 linear_num = 512
 batch_size = 256
 folder_path = str(pathlib.Path(__file__).parent)
-_ = timm.create_model("swin_base_patch4_window7_224", pretrained=True)
 
 use_gpu = torch.cuda.is_available()
 gpu_ids = [0]

--- a/vision/packages/vision_general/vision_general/utils/reid_model.py
+++ b/vision/packages/vision_general/vision_general/utils/reid_model.py
@@ -9,7 +9,6 @@ from PIL import Image
 from torch.autograd import Variable
 from scipy.spatial.distance import cosine
 import pathlib
-import timm
 
 version = torch.__version__
 use_swin = True


### PR DESCRIPTION
```python
timm.create_model("swin_base_patch4_window7_224", pretrained=True)
```
This line was loading a pretrained model from the internet. Now it loads only the structure and later on the weights. The load was also unnecessary in `reid_model.py`.

*Needs testing in FRIDA