### PR TITLE
don't run ollama for cpu

### DIFF
--- a/docker/hri/docker-compose-gpu.yml
+++ b/docker/hri/docker-compose-gpu.yml
@@ -1,6 +1,7 @@
 include:
   - path: hri-ros.yaml
   - path: stt.yaml
+  - path: ollama.yaml
   - path: postgresql.yaml
   - path: display.yaml
   - path: tts.yaml

--- a/docker/hri/run.sh
+++ b/docker/hri/run.sh
@@ -162,6 +162,7 @@ cleanup() {
 trap cleanup SIGINT
 
 compose_file="docker-compose-cpu.yml"
+[ "$ENV_TYPE" == "gpu" ] && compose_file="docker-compose-gpu.yml"
 [ "$ENV_TYPE" == "jetson" ] && compose_file="docker-compose.yml"
 
 if [ -n "$detached" ]; then


### PR DESCRIPTION
Created new docker-compose file which runs all hri containers, however if user is running on cpu creating starting ollama will throw an error because they don't have nvidia runtime, this is why they should use cpu.yml which doesn't start it.