### PR TITLE
Improved run.sh for hri

### DIFF
--- a/auto-complete.sh
+++ b/auto-complete.sh
@@ -20,8 +20,11 @@ _run_sh_autocomplete() {
         1)
             options="$areas"
             ;;
-        *)
+        2)
             options="$tasks"
+            ;;
+        *)  
+            options=""
             ;;
     esac
     

--- a/auto-complete.sh
+++ b/auto-complete.sh
@@ -4,21 +4,28 @@ _run_sh_autocomplete() {
     local cur prev words cword
     _init_completion || return
 
-    local areas="manipulation navigation hri vision integration"
+    local areas="manipulation navigation hri vision integration zed"
     local tasks="--carry --receptionist --storing-groceries --gpsr --moondream --egpsr --clean-table --hand --restaurant"
     local flags="--rebuild --help -h -d"
-
-    case ${COMP_CWORD} in
-        1)
-            COMPREPLY=( $(compgen -W "$areas $flags" -- "$cur") )
-            ;;
-        2)
-            COMPREPLY=( $(compgen -W "$tasks $flags" -- "$cur") )
-            ;;
-        *)
-            COMPREPLY=( $(compgen -W "$flags" -- "$cur") )
+    
+    # Add area specific flags
+    case "${words[1]}" in
+        hri)
+            flags="$flags --build-display --open-display --download-model"
             ;;
     esac
+
+    local options
+    case ${COMP_CWORD} in
+        1)
+            options="$areas"
+            ;;
+        *)
+            options="$tasks"
+            ;;
+    esac
+    
+    COMPREPLY=( $(compgen -W "$options $flags" -- "$cur") )
 }
 
 complete -F _run_sh_autocomplete ./run.sh

--- a/docker/hri/display.yaml
+++ b/docker/hri/display.yaml
@@ -13,9 +13,8 @@ services:
     environment:
       ROS_LOCALHOST_ONLY: 1
     ports:
-      - "3000:3000"
-      - "8001:8001"
-      - "8080:8080"
+      - '3000:3000'
+      - '8001:8001'
+      - '8080:8080'
     network_mode: host
-    command:
-      ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && npm run start"]
+    command: ['/bin/bash', '/display-entrypoint.sh']

--- a/docker/hri/display.yaml
+++ b/docker/hri/display.yaml
@@ -17,4 +17,5 @@ services:
       - "8001:8001"
       - "8080:8080"
     network_mode: host
-    command: ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && npm run dev"]
+    command:
+      ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && npm run start"]

--- a/docker/hri/run.sh
+++ b/docker/hri/run.sh
@@ -4,10 +4,19 @@ ARGS=("$@")  # Save all arguments in an array
 TASK=${ARGS[0]}
 
 detached=""
-# check if one of the arguments is --detached
+build_display=""
+open_display=""
+download_model=""
+# check if one of the arguments is --detached, --build-display, or --open-display
 for arg in "${ARGS[@]}"; do
   if [ "$arg" == "-d" ]; then
     detached="-d"
+  elif [ "$arg" == "--build-display" ]; then
+    build_display="true"
+  elif [ "$arg" == "--open-display" ]; then
+    open_display="true"
+  elif [ "$arg" == "--download-model" ]; then
+    download_model="true"
   fi
 done
 
@@ -63,7 +72,6 @@ fi
 echo "Detected environment: $ENV_TYPE"
 
 # Build base image
-
 case $ENV_TYPE in
   "gpu")
     ;&
@@ -90,16 +98,14 @@ esac
 #_________________________SETUP_________________________
 
 bash setup.bash
-
-# TODO: Uncomment this if you need to download the model
-# bash ../../hri/packages/nlp/assets/download-model.sh
+[ "$download_model" == "true" ] && bash ../../hri/packages/nlp/assets/download-model.sh
 
 # Create dirs with current user to avoid permission problems
 mkdir -p install build log ../../hri/packages/speech/assets/downloads/offline_voice/model/
 
 
 # Check if display setup is needed
-if [ ! -d "../../hri/display/dist" ] || [ ! -d "../../hri/display/node_modules" ] || [ ! -d "../../hri/display/web-ui/.next" ] || [ ! -d "../../hri/display/web-ui/node_modules" ]; then
+if [ ! -d "../../hri/display/dist" ] || [ ! -d "../../hri/display/node_modules" ] || [ ! -d "../../hri/display/web-ui/.next" ] || [ ! -d "../../hri/display/web-ui/node_modules" ] || [ "$build_display" == "true" ]; then
   echo "Setting up display environment..."
 
   compose_file="display.yaml"
@@ -154,46 +160,39 @@ add_or_update_variable .env "COMMAND" "$COMMAND"
 
 # Trap Ctrl+C to clean up
 cleanup() {
-  echo -e "\n🛑 Interrupted. Cleaning up..."
   [ -n "$compose_pid" ] && kill "$compose_pid" 2>/dev/null
   [ -n "$curl_pid" ] && kill "$curl_pid" 2>/dev/null
   exit 1
 }
 trap cleanup SIGINT
 
-compose_file="docker-compose-cpu.yml"
-[ "$ENV_TYPE" == "gpu" ] && compose_file="docker-compose-gpu.yml"
-[ "$ENV_TYPE" == "jetson" ] && compose_file="docker-compose.yml"
-
-if [ -n "$detached" ]; then
-  echo "🚀 Launching containers in detached mode..."
-  docker compose -f "$compose_file" up -d
-
-  echo "⏳ Waiting for localhost:3000 to be available..."
+# Function to wait for service and launch display
+wait_and_launch_display() {
   until curl --output /dev/null --silent --head --fail http://localhost:3000; do
     printf '.'
     sleep 1
   done
-  echo -e "\n✅ Web service is up. Launching Firefox..."
   bash open-display.bash
+}
 
+compose_file="docker-compose-cpu.yml"
+[ "$ENV_TYPE" == "gpu" ] && compose_file="docker-compose-gpu.yml"
+[ "$ENV_TYPE" == "jetson" ] && compose_file="docker-compose.yml"
+
+# Run the selected docker compose file
+if [ -n "$detached" ]; then
+  docker compose -f "$compose_file" up -d
+  [ "$open_display" == "true" ] && wait_and_launch_display
 else
-  echo "🚀 Launching containers in attached mode..."
   ROLE=$PROFILES docker compose -f "$compose_file" up &
   compose_pid=$!
 
-  echo "⏳ Waiting for localhost:3000 to be available..."
-  (
-    while ! curl --output /dev/null --silent --head --fail http://localhost:3000; do
-      printf '.'
-      sleep 1
-    done
-    echo -e "\n✅ Web service is up. Launching Firefox..."
-    bash open-display.bash
-  ) &
-  curl_pid=$!
+  if [ "$open_display" == "true" ]; then
+    wait_and_launch_display &
+    curl_pid=$!
+  fi
 
-  # Wait for docker compose to finish, then kill the curl loop
+  # Wait for docker compose to finish, then kill the curl loop if it exists
   wait $compose_pid
-  kill $curl_pid 2>/dev/null
+  [ -n "$curl_pid" ] && kill $curl_pid 2>/dev/null
 fi

--- a/docker/hri/run.sh
+++ b/docker/hri/run.sh
@@ -3,11 +3,12 @@
 ARGS=("$@")  # Save all arguments in an array
 TASK=${ARGS[0]}
 
+# IMPORTANT: Also edit auto-complete.sh to add new arguments
 detached=""
 build_display=""
 open_display=""
 download_model=""
-# check if one of the arguments is --detached, --build-display, or --open-display
+# Check if one of the arguments is --detached, --build-display, or --open-display
 for arg in "${ARGS[@]}"; do
   if [ "$arg" == "-d" ]; then
     detached="-d"


### PR DESCRIPTION
* Added missing area `zed` to `auto-complete.sh`, improved implementation and added hri specific arguments.
* Run `npm run start` instead of `dev`.
* Implemented `--open-display`, `--build-display` and `--download-model` arguments in `docker/hri/run.sh`.