### PR TITLE
Stop.sh

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # stop.sh - Kill all tmux sessions and stop all running Docker containers.
 
 set -euo pipefail #if error
@@ -16,11 +17,10 @@ fi
 if command -v docker >/dev/null 2>&1; then
     if docker info >/dev/null 2>&1; then
         running_containers="$(docker ps -q)"
-        if [ -n "${running_containers}" ]; then
+        if [ -n "$running_containers" ]; then
             echo "Stopping running Docker containers..."
-            # shellcheck disable=SC2086
-            docker stop ${running_containers} >/dev/null
-            echo "Stopped containers: ${running_containers}"
+            docker stop $running_containers >/dev/null
+            echo "Stopped containers: $running_containers"
         else
             echo "No running Docker containers."
         fi


### PR DESCRIPTION

Added `stop.sh`, which kills all active `tmux` sessions if `tmux` is installed and stops all running Docker containers if Docker is available and the daemon is reachable.

<img width="962" height="523" alt="image" src="https://github.com/user-attachments/assets/97be6222-c32f-4662-8919-d335374155fb" />
<img width="343" height="234" alt="image" src="https://github.com/user-attachments/assets/547344c2-a11b-4d83-8937-841b8ed1a19b" />
<img width="475" height="234" alt="image" src="https://github.com/user-attachments/assets/254e5b00-9917-46bc-86b8-9484daaeab6a" />
