### PR TITLE
feat(#567): add flag to run.sh for db cleanup and repopulation

### DIFF
--- a/auto-complete.sh
+++ b/auto-complete.sh
@@ -12,7 +12,7 @@ _run_sh_autocomplete() {
     # Add area specific flags
     case "${words[1]}" in
         hri)
-            flags="$flags --build-display --open-display --download-model"
+            flags="$flags --build-display --open-display --download-model --regenerate-db"
             ;;
         integration)
             # TODO: add other important scripts


### PR DESCRIPTION
- If the flag is detected: SQL dumps are generated, the postgres volume is removed, the postgres image is rebuilt  and the container is restarted
- Auto complete added for the flag (regenerate-db)