### PR TITLE
fix start rerunning initialization command

### DIFF
--- a/docker/hri/run.sh
+++ b/docker/hri/run.sh
@@ -139,7 +139,6 @@ COMPOSE_PROFILES=$(IFS=, ; echo "${PROFILES[*]}")
 add_or_update_variable compose/.env "COMPOSE_PROFILES" "$COMPOSE_PROFILES"
 
 COMMAND="$GENERATE_BAML_CLIENT && $SOURCE_ROS && $SOURCE_INTERFACES && $BUILD_COMMAND source ~/.bashrc && $RUN"
-add_or_update_variable compose/.env "COMMAND" "$COMMAND"
 add_or_update_variable compose/.env "ROLE" "${PROFILES[0]}"
 
 cleanup() {
@@ -163,13 +162,12 @@ if [ -n "$OPEN_DISPLAY" ]; then
 fi
 
 if [ "$RUN" = "bash" ] && [ -z "$DETACHED" ]; then
-    EXISTING_CONTAINER=$(docker ps -a -q -f name="hri")
-    if [ -z "$EXISTING_CONTAINER" ] || [ -n "$BUILD_IMAGE" ]; then
+    ALREADY_RUNNING=$(docker ps -q -f name="hri-ros")
+    if [ -z "$ALREADY_RUNNING" ] || [ -n "$BUILD_IMAGE" ]; then
         docker compose -f "$COMPOSE" up -d $BUILD_IMAGE
-    else
-        docker compose -f "$COMPOSE" start
     fi
     docker compose -f "$COMPOSE" exec hri-ros bash -c "$COMMAND"
 else
+    add_or_update_variable compose/.env "COMMAND" "$COMMAND"
     docker compose -f "$COMPOSE" up $DETACHED $BUILD_IMAGE
 fi

--- a/docker/integration/run.sh
+++ b/docker/integration/run.sh
@@ -97,16 +97,14 @@ case $TASK in
 esac
 
 COMMAND="$SETUP && $RUN"
-add_or_update_variable .env "COMMAND" "$COMMAND"
 
 if [ "$RUN" = "bash" ] && [ -z "$DETACHED" ]; then
-    EXISTING_CONTAINER=$(docker ps -a -q -f name="integration")
-    if [ -z "$EXISTING_CONTAINER" ] || [ -n "$BUILD_IMAGE" ]; then
+    ALREADY_RUNNING=$(docker ps -q -f name="integration")
+    if [ -z "$ALREADY_RUNNING" ] || [ -n "$BUILD_IMAGE" ]; then
         docker compose up -d $BUILD_IMAGE
-    else
-        docker compose start
     fi
     docker compose exec integration bash -c "$COMMAND"
 else
+    add_or_update_variable .env "COMMAND" "$COMMAND"
     docker compose up $DETACHED $BUILD_IMAGE
 fi

--- a/docker/manipulation/run.sh
+++ b/docker/manipulation/run.sh
@@ -87,16 +87,14 @@ case $TASK in
 esac
 
 COMMAND="$SETUP && $RUN"
-add_or_update_variable .env "COMMAND" "$COMMAND"
 
 if [ "$RUN" = "bash" ] && [ -z "$DETACHED" ]; then
-    EXISTING_CONTAINER=$(docker ps -a -q -f name="manipulation")
-    if [ -z "$EXISTING_CONTAINER" ] || [ -n "$BUILD_IMAGE" ]; then
+    ALREADY_RUNNING=$(docker ps -q -f name="manipulation")
+    if [ -z "$ALREADY_RUNNING" ] || [ -n "$BUILD_IMAGE" ]; then
         docker compose -f "$COMPOSE" up -d $BUILD_IMAGE
-    else
-        docker compose -f "$COMPOSE" start
     fi
     docker compose -f "$COMPOSE" exec manipulation bash -c "$COMMAND"
 else
+    add_or_update_variable .env "COMMAND" "$COMMAND"
     docker compose -f "$COMPOSE" up $DETACHED $BUILD_IMAGE
 fi

--- a/docker/navigation/run.sh
+++ b/docker/navigation/run.sh
@@ -82,16 +82,14 @@ case $TASK in
 esac
 
 COMMAND="$SETUP && $RUN"
-add_or_update_variable .env "COMMAND" "$COMMAND"
 
 if [ "$RUN" = "bash" ] && [ -z "$DETACHED" ]; then
-    EXISTING_CONTAINER=$(docker ps -a -q -f name="navigation")
-    if [ -z "$EXISTING_CONTAINER" ] || [ -n "$BUILD_IMAGE" ]; then
+    ALREADY_RUNNING=$(docker ps -q -f name="navigation")
+    if [ -z "$ALREADY_RUNNING" ] || [ -n "$BUILD_IMAGE" ]; then
         docker compose up -d $BUILD_IMAGE
-    else
-        docker compose start
     fi
     docker compose exec navigation bash -c "$COMMAND"
 else
+    add_or_update_variable .env "COMMAND" "$COMMAND"
     docker compose up $DETACHED $BUILD_IMAGE
 fi

--- a/docker/vision/run.sh
+++ b/docker/vision/run.sh
@@ -117,20 +117,18 @@ fi
 
 COMMAND="$SETUP && $RUN"
 COMMAND_MOONDREAM="$SOURCE_ROS && $SOURCE_INTERFACES && colcon build $IGNORE_PACKAGES --packages-up-to $MOONDREAM_PACKAGES && $SOURCE && $MOONDREAM_COMMAND"
-add_or_update_variable .env "COMMAND" "$COMMAND"
 add_or_update_variable .env "COMMAND_MOONDREAM" "$COMMAND_MOONDREAM"
 
 COMPOSE_PROFILES=$(IFS=, ; echo "${PROFILES[*]}")
 add_or_update_variable .env "COMPOSE_PROFILES" "$COMPOSE_PROFILES"
 
 if [ "$RUN" = "bash" ] && [ -z "$DETACHED" ]; then
-    EXISTING_CONTAINER=$(docker ps -a -q -f name="vision")
-    if [ -z "$EXISTING_CONTAINER" ] || [ -n "$BUILD_IMAGE" ]; then
+    ALREADY_RUNNING=$(docker ps -q -f name="vision")
+    if [ -z "$ALREADY_RUNNING" ] || [ -n "$BUILD_IMAGE" ]; then
         docker compose up -d $BUILD_IMAGE
-    else
-        docker compose start
     fi
     docker compose exec vision bash -c "$COMMAND"
 else
+    add_or_update_variable .env "COMMAND" "$COMMAND"
     docker compose up $DETACHED $BUILD_IMAGE
 fi


### PR DESCRIPTION
It was discovered that running `docker compose  start` started the container but ran in the background the `command` with which it was created. For example, if I created the container with a build command, every time the container gets started it will build in the background again. To avoid this instead we should run `up` which checks if the compose changed and recreates the container in such case, if the container is already running and it didn't change it does nothing.

Also moved the assignation of `COMMAND` below to avoid running it twice on the first if block