### PR TITLE
Update Main Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,36 @@ The `run.sh` script automatically detects your environment (CPU, CUDA, or L4T) a
 ./run.sh --restaurant
 ```
 
-### Available Flags
+### Available Areas
+
+| Area | Description |
+| --- | --- |
+| `vision` | Spins up the containers for the vision area |
+| `manipulation` | Spins up the containers for manipulation |
+| `navigation` | Spins up the containers for navigation |
+| `hri` | Spins up the containers for human-robot interaction |
+| `integration` | Spins up the complete integration environment |
+| `frida_interfaces` | Builds and configures FRIDA's custom interfaces/messages |
+
+### Competition Tasks
+
+| Flag | Description |
+| --- | --- |
+| `--hric` | Runs the Human-Robot Interaction challenge |
+| `--ppc` | Runs the Pick and Place challenge |
+| `--gpsr` | Runs the General Purpose Service Robot challenge |
+| `--dlc` | Runs the Doing Laundry Challenge |
+| `--restaurant` | Runs the Restaurant challenge |
+| `--finals` | Runs the finals stage routine |
+
+### Control Commands
+
+| Flag | Description |
+| --- | --- |
+| `--stop` | Stops the running containers without removing them |
+| `--down` | Stops and removes all containers, networks, and volumes |
+
+### Additional Flags
 
 | Flag | Description |
 | --- | --- |
@@ -62,8 +91,6 @@ The `run.sh` script automatically detects your environment (CPU, CUDA, or L4T) a
 | `--build-image` | Builds the Docker image for the specified area or task |
 | `--recreate` | Forces the recreation of containers |
 | `--open-display` | Opens the graphical interface for HRI or Vision |
-| `--stop` | Stops the running containers |
-| `--down` | Stops and removes all containers, networks, and volumes |
 
 ## Cyclone DDS Setup
 


### PR DESCRIPTION
ChangeLog
  - Replaced the old manual installation steps (ROS 2 Humble, colcon build, prebuild.sh) with the new Docker based workflow using run.sh
  - Updated prerequisites to Docker, Docker Compose, and optionally NVIDIA Container Toolkit
  - Added a project description explaining the team, competition, and architecture
  - Restructured the README for better organization: added table of contents, fixed heading hierarchy, consolidated documentation links
  - Renamed "Legacy" section to "Past Contributors"
  - Added new video demonstration
  - Removed $ prefixes from bash examples for easier copy paste