### PR TITLE
Add group_add option and update environment variables in Docker Compose

### DIFF
--- a/docker/manipulation/docker-compose-cuda.yaml
+++ b/docker/manipulation/docker-compose-cuda.yaml
@@ -25,6 +25,8 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    group_add: 
+      - video
     network_mode: host
     user: ${LOCAL_USER_ID}:${LOCAL_GROUP_ID}
     privileged: true
@@ -32,8 +34,11 @@ services:
       - /dev:/dev
       - /dev/video0:/dev/video0
     environment:
-      DISPLAY: :0
+      DISPLAY: ${DISPLAY}
       TERM: xterm-256color
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: all
+      QT_X11_NO_MITSHM: 1
     # Memory limits for non-Ubuntu distributions
     ulimits:
       nofile:

--- a/navigation/packages/map_context/CMakeLists.txt
+++ b/navigation/packages/map_context/CMakeLists.txt
@@ -12,8 +12,8 @@ find_package(ament_index_cpp REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclpy REQUIRED)
 find_package(rviz2 REQUIRED)
-find_package(frida_interfaces REQUIRED)
 find_package(nlohmann_json REQUIRED)
+find_package(frida_interfaces REQUIRED)
 #Directory install
 install(DIRECTORY launch config maps
   DESTINATION share/${PROJECT_NAME})

--- a/navigation/packages/map_context/package.xml
+++ b/navigation/packages/map_context/package.xml
@@ -17,7 +17,8 @@
   <depend>rviz2</depend>
   <!--C++ dependencies -->
   <depend>nlohmann-json-dev</depend>
-
+  <!-- Package dependencies -->
+  <depend>frida_interfaces</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
This pull request updates the `docker-compose-cuda.yaml` configuration to improve GPU container compatibility and support video device access. The most important changes focus on enabling video group permissions, updating environment variables for better GPU and display handling, and ensuring compatibility with NVIDIA drivers.

Container permissions and device access:

* Added `group_add` with the `video` group to allow container processes to access video devices like `/dev/video0`.

Environment variable updates for GPU and display support:

* Changed the `DISPLAY` environment variable to use `${DISPLAY}` for dynamic assignment, improving compatibility with host display settings.
* Added `NVIDIA_VISIBLE_DEVICES=all` and `NVIDIA_DRIVER_CAPABILITIES=all` to ensure the container has access to all GPUs and full NVIDIA driver features.
* Added `QT_X11_NO_MITSHM=1` to address potential issues with Qt applications running in X11 environments inside the container.