### PR TITLE
Hri/change tts image

### DIFF
--- a/docker/hri/compose/tts.yaml
+++ b/docker/hri/compose/tts.yaml
@@ -6,7 +6,7 @@ services:
       context: ../../..
       dockerfile: docker/hri/dockerfiles/Dockerfile.tts
       args:
-        BASE_IMAGE: roborregos/home2:${ENV_TYPE:-cpu}_base
+        BASE_IMAGE: ${TTS_BASE_IMAGE:-python:3.9-bookworm}
     volumes:
       - ../../../hri/packages/speech/scripts/tts/:/app
       - ../../../hri/packages/speech/assets/downloads/offline_voice/audios/:/app/audios

--- a/docker/hri/compose/tts.yaml
+++ b/docker/hri/compose/tts.yaml
@@ -6,7 +6,7 @@ services:
       context: ../../..
       dockerfile: docker/hri/dockerfiles/Dockerfile.tts
       args:
-        BASE_IMAGE: ${TTS_BASE_IMAGE:-python:3.9-bookworm}
+        BASE_IMAGE: python:3.10-bookworm
     volumes:
       - ../../../hri/packages/speech/scripts/tts/:/app
       - ../../../hri/packages/speech/assets/downloads/offline_voice/audios/:/app/audios
@@ -21,4 +21,9 @@ services:
       PULSE_SERVER: unix:/tmp/pulse/pulseaudio.socket
       PULSE_COOKIE: /tmp/pulse/pulseaudio.cookie
       HF_HUB_DISABLE_XET: 1
+      HOME: /app
+      HF_HOME: /app/.cache/huggingface
+      HUGGINGFACE_HUB_CACHE: /app/.cache/huggingface/hub
+      TRANSFORMERS_CACHE: /app/.cache/huggingface/transformers
+      XDG_CACHE_HOME: /app/.cache
     command: "python3 kokoro-tts.py --port 50050"

--- a/docker/hri/dockerfiles/Dockerfile.tts
+++ b/docker/hri/dockerfiles/Dockerfile.tts
@@ -9,8 +9,8 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 RUN pip install --upgrade protobuf
 RUN python3 -m spacy download en_core_web_sm
 
-RUN sudo apt update && \
-    sudo apt install -y \
+RUN apt update && \
+    apt install -y \
     libopenmpi-dev \
     libportaudio2 \
     libportaudiocpp0 \


### PR DESCRIPTION
This PR updates the TTS container base image.

**Main changes**
- Switched the TTS base image to `python:3.10-bookworm`, avoiding the use of the RoboRegros base image that included ROS 2 unnecessarily.
- Added explicit Hugging Face/Transformers cache environment variables in `tts.yaml`:
  - `HOME=/app`
  - `HF_HOME=/app/.cache/huggingface`
  - `HUGGINGFACE_HUB_CACHE=/app/.cache/huggingface/hub`
  - `TRANSFORMERS_CACHE=/app/.cache/huggingface/transformers`
  - `XDG_CACHE_HOME=/app/.cache`

**Why**
The container runs as a non-root user and the default cache path was resolving to `/.cache`, causing:
`PermissionError: [Errno 13] Permission denied: '/.cache'`.

**Expected impact**
- Prevents Hugging Face cache writes to non-writable system paths.
- Avoids using the RoboRegros ROS 2 image when it is not required.
- Makes Kokoro TTS startup more reliable across environments (including L4T).

No API or behavior changes to the TTS service.