### PR TITLE
chenge stt base image to python:3.10-bookworm

### DIFF
--- a/docker/hri/dockerfiles/Dockerfile.stt
+++ b/docker/hri/dockerfiles/Dockerfile.stt
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
This change is useful to having the same base image between stt and tts dockers