### PR TITLE
Fix test manipulation task manager

### DIFF
--- a/task_manager/scripts/test/test_manipulation_manager.py
+++ b/task_manager/scripts/test/test_manipulation_manager.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 
-import sys
 import os
+import sys
 
 _script_dir = os.path.dirname(os.path.abspath(__file__))
 if _script_dir not in sys.path:
     sys.path.insert(0, _script_dir)
 
-import rclpy
-from rclpy.node import Node
-from utils.status import Status
-from utils.task import Task
-from subtask_managers.manipulation_tasks import ManipulationTasks
+import rclpy  # noqa: E402
+from rclpy.node import Node  # noqa: E402
+from utils.status import Status  # noqa: E402
+from utils.task import Task  # noqa: E402
+from subtask_managers.manipulation_tasks import ManipulationTasks  # noqa: E402
 
 
 class TestManipulationManager(Node):

--- a/task_manager/scripts/test/test_manipulation_manager.py
+++ b/task_manager/scripts/test/test_manipulation_manager.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
 
+import sys
+import os
+
+_script_dir = os.path.dirname(os.path.abspath(__file__))
+if _script_dir not in sys.path:
+    sys.path.insert(0, _script_dir)
+
 import rclpy
 from rclpy.node import Node
 from utils.status import Status


### PR DESCRIPTION
This pull request makes a minor update to the test script for the manipulation manager by ensuring the script's directory is included in the Python path. This change helps prevent import errors when running the script directly.

* Added logic in `test_manipulation_manager.py` to insert the script's directory into `sys.path` if it's not already present, improving module import reliability.