### PR TITLE
feat: Update EEF_CONTACT_LINKS to include additional gripper and fing…

### DIFF
--- a/frida_constants/frida_constants/manipulation_constants.py
+++ b/frida_constants/frida_constants/manipulation_constants.py
@@ -1,7 +1,7 @@
 from math import pi as PI
 
 EEF_LINK_NAME = "link_eef"
-EEF_CONTACT_LINKS = ["link_eef", "link_6"]
+EEF_CONTACT_LINKS = ["link_eef", "link_6", "gripper", "left_finger", "right_finger"]
 
 DEG2RAD = PI / 180.0
 RAD2DEG = 180.0 / PI


### PR DESCRIPTION
### Collision Fix (pick+place reliability)
- Added `gripper`, `left_finger`, `right_finger` to `EEF_CONTACT_LINKS` — MoveIt was rejecting valid plans because gripper links "collided" with attached object spheres