### PR TITLE
feat: Update build commands to include xarm_msgs package

### DIFF
--- a/docker/frida_interfaces_cache/docker-compose-cpu.yaml
+++ b/docker/frida_interfaces_cache/docker-compose-cpu.yaml
@@ -15,4 +15,4 @@ services:
     tty: true
     user: ${UID}:${GID}
     entrypoint: ["bash", "-il", "-c"]
-    command: ["source /opt/ros/humble/setup.bash && colcon build --packages-select frida_interfaces frida_constants"]
+    command: ["source /opt/ros/humble/setup.bash && colcon build --packages-select frida_interfaces frida_constants xarm_msgs"]

--- a/docker/integration/run.sh
+++ b/docker/integration/run.sh
@@ -89,7 +89,7 @@ GENERATE_BAML_CLIENT="baml-cli generate --from /workspace/src/task_manager/task_
 SOURCE_ROS="source /opt/ros/humble/setup.bash"
 SOURCE_INTERFACES="if [ -f frida_interfaces_cache/install/local_setup.bash ]; then source frida_interfaces_cache/install/local_setup.bash; fi"
 SOURCE="if [ -f install/setup.bash ]; then source install/setup.bash; fi"
-COLCON="colcon build --symlink-install --packages-ignore frida_interfaces frida_constants --packages-up-to task_manager"
+COLCON="colcon build --symlink-install --packages-ignore frida_interfaces frida_constants xarm_msgs --packages-up-to task_manager"
 
 if [ "$BUILD" == "true" ]; then
     SETUP="$GENERATE_BAML_CLIENT && $SOURCE_ROS && $SOURCE_INTERFACES && $COLCON && $SOURCE"

--- a/docker/manipulation/.bash_aliases
+++ b/docker/manipulation/.bash_aliases
@@ -1,1 +1,1 @@
-alias build='cd /workspace && source frida_interfaces_cache/install/local_setup.bash && colcon build --symlink-install --packages-up-to manipulation_general --packages-ignore realsense_gazebo_plugin xarm_gazebo frida_interfaces'
+alias build='cd /workspace && source frida_interfaces_cache/install/local_setup.bash && colcon build --symlink-install --packages-up-to manipulation_general --packages-ignore realsense_gazebo_plugin xarm_gazebo frida_interfaces xarm_msgs'

--- a/docker/manipulation/run.sh
+++ b/docker/manipulation/run.sh
@@ -79,7 +79,7 @@ SOURCE_INTERFACES="if [ -f frida_interfaces_cache/install/local_setup.bash ]; th
 GPD_SETUP=". /home/ros/setup_gpd.sh"
 GPD_EXPORT="export GPD_INSTALL_DIR=/workspace/install/gpd"
 SOURCE="if [ -f install/setup.bash ]; then source install/setup.bash; fi"
-COLCON="colcon build --symlink-install --packages-up-to manipulation_general --packages-ignore realsense_gazebo_plugin xarm_gazebo frida_interfaces"
+COLCON="colcon build --symlink-install --packages-up-to manipulation_general --packages-ignore realsense_gazebo_plugin xarm_gazebo frida_interfaces xarm_msgs"
 
 if [ "$BUILD" == "true" ]; then
     SETUP="$GPD_SETUP && $GPD_EXPORT && $SOURCE_ROS && $SOURCE_INTERFACES && $COLCON && $SOURCE"


### PR DESCRIPTION
## Move xarm_msgs build to frida_interfaces cache

xarm_msgs (47 .srv + 3 .msg) was being rebuilt from source 
in both manipulation and integration containers on every 
colcon build. Moved it to the frida_interfaces cache so it 
builds once and all containers source it.

### Changes
- `docker/frida_interfaces_cache/docker-compose-cpu.yaml`: Added xarm_msgs to --packages-select (now consistent with CUDA/L4T caches)
- `docker/manipulation/run.sh`: Added xarm_msgs to --packages-ignore
- `docker/manipulation/.bash_aliases`: Updated build alias to ignore xarm_msgs
- `docker/integration/run.sh`: Added xarm_msgs to --packages-ignore

### No changes needed
- vision, navigation, hri (don't depend on xarm_msgs)
- CUDA/L4T cache (already included xarm_msgs)