### PR TITLE
Vision/refactor cutomer node

### DIFF
--- a/vision/packages/vision_general/scripts/customer_node.py
+++ b/vision/packages/vision_general/scripts/customer_node.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
 
 """
-Node to track a single person and
-re-id them if necessary
+Node to detect customers who are sitting and raising their hand.
+Uses YOLO pose on the full image for person detection + keypoints in one pass.
 """
 
 import cv2
-from vision_general.utils.trt_utils import load_yolo_trt
-import tqdm
-from builtin_interfaces.msg import Time
 from vision_general.utils.calculations import (
     get2DCentroid,
     point2d_to_ros_point_stamped,
@@ -19,9 +16,10 @@ from rclpy.node import Node
 from cv_bridge import CvBridge
 from sensor_msgs.msg import Image, CameraInfo
 from geometry_msgs.msg import Point, PointStamped
-
+from builtin_interfaces.msg import Time
 from frida_interfaces.srv import CropQuery, Customer
 from frida_interfaces.msg import PersonList, Person
+from vision_general.utils.ros_utils import wait_for_future
 from pose_detection import PoseDetection
 from frida_constants.vision_constants import (
     CAMERA_TOPIC,
@@ -35,8 +33,8 @@ from frida_constants.vision_constants import (
     GET_CUSTOMER_TOPIC,
 )
 
-CONF_THRESHOLD = 0.8
-DEPTH_THRESHOLD = 100
+CONF_THRESHOLD = 0.4
+CAMERA_FRAME = "zed_left_camera_optical_frame"
 
 
 class CustomerNode(Node):
@@ -64,62 +62,44 @@ class CustomerNode(Node):
         )
 
         self.get_customer_service = self.create_service(
-            Customer, GET_CUSTOMER_TOPIC, self.get_customer_callback
+            Customer,
+            GET_CUSTOMER_TOPIC,
+            self.get_customer_callback,
+            callback_group=self.callback_group,
         )
 
-        self.is_tracking_result = False
-
         self.results_publisher = self.create_publisher(PointStamped, RESULTS_TOPIC, 10)
-
         self.image_publisher = self.create_publisher(Image, TRACKER_IMAGE_TOPIC, 10)
-
         self.customer_publisher = self.create_publisher(Image, CUSTOMER, 10)
-
         self.centroid_publisher = self.create_publisher(Point, CENTROID_TOIC, 10)
 
         self.moondream_client = self.create_client(
             CropQuery, CROP_QUERY_TOPIC, callback_group=self.callback_group
         )
 
-        self.verbose = self.declare_parameter("verbose", True)
-        self.setup()
-        self.create_timer(0.1, self.run)
-        self.create_timer(0.1, self.publish_image)
-
-    def setup(self):
-        """Load models and initial variables"""
-        self.target_set = False
         self.image = None
-        self.image_time = None
-        self.frame_id = "zed_left_camera_optical_frame"
-
+        self.depth_image = None
         self.depth_image_time = None
-        pbar = tqdm.tqdm(total=1, desc="Loading models")
-
-        # Load YOLO with TensorRT for Orin AGX
-        self.model = load_yolo_trt("yolov8n.pt")
-        self.pose_detection = PoseDetection()
-
+        self.imageInfo = None
         self.output_image = []
-        self.depth_image = []
         self.customer_image = []
 
-        pbar.close()
-        self.get_logger().info("Single Tracker Ready")
+        self.pose_detection = PoseDetection()
+
+        self.create_timer(0.1, self.publish_image)
+        self.get_logger().info("Customer Node Ready")
 
     def image_callback(self, data):
         """Callback to receive image from camera"""
         self.image = self.bridge.imgmsg_to_cv2(data, "bgr8")
-        self.image_time = data.header.stamp
 
     def depth_callback(self, data):
         """Callback to receive depth image from camera"""
         try:
-            depth_image = self.bridge.imgmsg_to_cv2(data, "32FC1")
-            self.depth_image = depth_image
+            self.depth_image = self.bridge.imgmsg_to_cv2(data, "32FC1")
             self.depth_image_time = data.header.stamp
         except Exception as e:
-            print(f"Error: {e}")
+            self.get_logger().error(f"Error: {e}")
 
     def image_info_callback(self, data):
         """Callback to receive camera info"""
@@ -134,105 +114,111 @@ class CustomerNode(Node):
 
         if len(self.customer_image) != 0:
             h, w = self.customer_image.shape[:2]
-
             square_size = max(h, w)
-
             square_img = cv2.copyMakeBorder(
                 self.customer_image,
                 top=(square_size - h) // 2,
-                bottom=(square_size - h + 1) // 2,  # Handles odd differences
+                bottom=(square_size - h + 1) // 2,
                 left=(square_size - w) // 2,
                 right=(square_size - w + 1) // 2,
                 borderType=cv2.BORDER_CONSTANT,
-                value=(0, 0, 0),  # Black padding (BGR)
+                value=(0, 0, 0),
             )
             self.customer_publisher.publish(
                 self.bridge.cv2_to_imgmsg(square_img, "bgr8")
             )
 
-    def success(self, message) -> None:
-        """Print success message"""
-        self.get_logger().info(f"\033[92mSUCCESS:\033[0m {message}")
-
     def get_customer_callback(self, req, res):
-        """Set the target to track (Default: Largest person in frame)"""
         res.found = False
         res.people = PersonList()
         res.people.list = []
-        print("running")
+
         if self.image is None:
             self.get_logger().warn("No image available")
-
             return res
 
-        self.frame = self.image.copy()
-        self.output_image = self.frame.copy()
+        frame = self.image.copy()
+        self.output_image = frame.copy()
+        image_width = frame.shape[1]
 
-        for out in self.results:
-            for box in out.boxes:
-                if box.conf[0].item() < CONF_THRESHOLD:
-                    continue
+        people = self.pose_detection.detect_people(frame, conf=CONF_THRESHOLD)
+        self.get_logger().info(f"Detected {len(people)} people")
 
-                x1, y1, x2, y2 = [round(x) for x in box.xyxy[0].tolist()]
-                cv2.rectangle(self.output_image, (x1, y1), (x2, y2), (0, 0, 255), 2)
+        for person_data in people:
+            x1, y1, x2, y2 = person_data["bbox"]
+            points = person_data["keypoints"]
+            kp_conf = person_data["kp_conf"]
 
-                cropped_image = self.frame[y1:y2, x1:x2]
-                self.customer_image = cropped_image.copy()
+            # Expand bbox by 20% for moondream and debug image
+            h, w = frame.shape[:2]
+            bw, bh = x2 - x1, y2 - y1
+            pad_x, pad_y = int(bw * 0.1), int(bh * 0.1)
+            ex1 = max(0, x1 - pad_x)
+            ey1 = max(0, y1 - pad_y)
+            ex2 = min(w, x2 + pad_x)
+            ey2 = min(h, y2 + pad_y)
 
-                raising = self.pose_detection.is_waving_customer(cropped_image)
-                if not raising:
-                    self.get_logger().info("Customer not raising hand")
-                    continue
-                sitting = self.pose_detection.is_sitting_yolo(cropped_image)
+            cv2.rectangle(self.output_image, (x1, y1), (x2, y2), (0, 0, 255), 2)
+            self.pose_detection.draw_landmarks(self.output_image, points, kp_conf)
 
-                if not sitting:
-                    self.get_logger().info("Checking sitting with moondream")
-                    sitting = self.is_sitting_moondream([x1, y1, x2, y2])
+            self.customer_image = frame[ey1:ey2, ex1:ex2].copy()
 
-                if raising and sitting:
-                    self.get_logger().info("Customer raising hand and sitting detected")
-                    cv2.rectangle(self.output_image, (x1, y1), (x2, y2), (0, 255, 0), 2)
+            raising = self.pose_detection.is_waving_from_keypoints(points, kp_conf)
+            if not raising:
+                self.get_logger().info("Customer not raising hand")
+                continue
 
-                    # 2D Centroid and Depth
-                    point2D = get2DCentroid((y1, x1, y2, x2), self.depth_image)
-                    coords = point2d_to_ros_point_stamped(
-                        self.imageInfo,
-                        self.depth_image,
-                        point2D,
-                        self.frame_id,
-                        Time(sec=0, nanosec=0),
-                    )
-                    self.results_publisher.publish(coords)
+            sitting = self.pose_detection.is_sitting_from_keypoints(points, kp_conf)
+            if not sitting:
+                self.get_logger().info("Checking sitting with moondream")
+                sitting = self.is_sitting_moondream([ex1, ey1, ex2, ey2])
 
-                    # Normalize X coordinate for basic tracking
-                    pt_x_norm = float(point2D[1]) / (self.frame.shape[1] / 2) - 1.0
-                    self.centroid_publisher.publish(Point(x=pt_x_norm, y=0.0, z=0.0))
+            if raising and sitting:
+                self.get_logger().info("Customer raising hand and sitting detected")
+                cv2.rectangle(self.output_image, (x1, y1), (x2, y2), (0, 255, 0), 2)
 
-                    # Append to results
-                    person = Person()
-                    person.x = (x1 + x2) // 2
-                    person.y = (y1 + y2) // 2
-                    person.point3d = coords
-                    res.people.list.append(person)
+                point2D = get2DCentroid((y1, x1, y2, x2), self.depth_image)
+                coords = point2d_to_ros_point_stamped(
+                    self.imageInfo,
+                    self.depth_image,
+                    point2D,
+                    CAMERA_FRAME,
+                    Time(sec=0, nanosec=0),
+                )
+                self.results_publisher.publish(coords)
 
-                    res.found = True
-                    self.success("Customer found")
-                    self.get_logger().info(
-                        f"Customer position (3D): x={coords.point.x:.3f}  y={coords.point.y:.3f}  z={coords.point.z:.3f}"
-                    )
+                pt_x_norm = float(point2D[1]) / (frame.shape[1] / 2) - 1.0
+                self.centroid_publisher.publish(Point(x=pt_x_norm, y=0.0, z=0.0))
+
+                person = Person()
+                person.x = (x1 + x2) // 2
+                person.y = (y1 + y2) // 2
+                person.point3d = coords
+                diff = person.x - (image_width / 2)
+                max_degree = 50.0
+                angle = diff * max_degree / (image_width / 2)
+                if hasattr(person, "angle"):
+                    person.angle = angle
+                res.people.list.append(person)
+
+                res.found = True
+                self.get_logger().info(
+                    f"Customer position (3D): x={coords.point.x:.3f}  y={coords.point.y:.3f}  z={coords.point.z:.3f}, angle={angle:.1f}"
+                )
 
         self.get_logger().info(f"Customers detected: {len(res.people.list)}")
         return res
 
     def is_sitting_moondream(self, bbox):
-        if self.frame is None or bbox is None:
+        if self.image is None or bbox is None:
             return False
 
         if not self.moondream_client.wait_for_service(timeout_sec=0.1):
             self.get_logger().warn("Moondream crop query service not available")
             return False
 
-        height, width = self.frame.shape[:2]
+        frame = self.image.copy()
+        height, width = frame.shape[:2]
         x1, y1, x2, y2 = bbox
         if width <= 0 or height <= 0:
             return False
@@ -252,14 +238,10 @@ class CustomerNode(Node):
         )
 
         future = self.moondream_client.call_async(request)
-        rclpy.spin_until_future_complete(self, future, timeout_sec=7)
+        wait_for_future(future)
 
         if not future.done():
             self.get_logger().warn("Service call timed out")
-            return False
-
-        if future.exception() is not None:
-            self.get_logger().error(f"Service call failed: {future.exception()}")
             return False
 
         result = future.result()
@@ -277,50 +259,15 @@ class CustomerNode(Node):
         )
         return False
 
-    def run(self):
-        """Main loop to run the tracker"""
-
-        if True:  # self.target_set:
-            self.frame = self.image
-            # image_time = copy.deepcopy(self.image_time)
-            # depth_image_time = copy.deepcopy(self.depth_image_time)
-            if self.frame is None:
-                self.get_logger().error("No image available")
-                return
-
-            if self.frame is None:
-                return
-
-            self.output_image = self.frame.copy()
-
-            self.results = self.model.track(
-                self.frame,
-                persist=True,
-                tracker="bytetrack.yaml",
-                classes=0,
-                verbose=False,
-            )
-
-            # Check each detection
-            for out in self.results:
-                for box in out.boxes:
-                    x1, y1, x2, y2 = [round(x) for x in box.xyxy[0].tolist()]
-
-                    cv2.rectangle(self.output_image, (x1, y1), (x2, y2), (0, 0, 255), 2)
-
-                    # Get confidence
-                    prob = round(box.conf[0].item(), 2)
-
-                    if prob < CONF_THRESHOLD:
-                        continue
-
 
 def main(args=None):
     rclpy.init(args=args)
     node = CustomerNode()
 
+    executor = rclpy.executors.MultiThreadedExecutor()
+    executor.add_node(node)
     try:
-        rclpy.spin(node)
+        executor.spin()
     except KeyboardInterrupt:
         pass
     finally:

--- a/vision/packages/vision_general/scripts/customer_node.py
+++ b/vision/packages/vision_general/scripts/customer_node.py
@@ -248,6 +248,10 @@ class CustomerNode(Node):
         if result is None or not result.success:
             return False
 
+        if future.exception() is not None:
+            self.get_logger().error(f"Service call failed: {future.exception()}")
+            return False
+
         answer = result.result.strip().lower()
         if answer.startswith("yes"):
             return True

--- a/vision/packages/vision_general/scripts/pose_detection.py
+++ b/vision/packages/vision_general/scripts/pose_detection.py
@@ -51,6 +51,84 @@ class PoseDetection:
         print("Pose Detection Ready (YOLO TensorRT)")
         self.yolo_pose = load_yolo_pose("yolo11m-pose.pt")
 
+    # ── Full-image detection ──
+
+    def detect_people(self, image, conf=0.4):
+        """Run YOLO pose on full image. Returns list of dicts with
+        'bbox' (x1,y1,x2,y2), 'confidence', 'keypoints' (17,2 normalized), 'kp_conf' (17,)."""
+        results = self.yolo_pose(image, verbose=False, conf=conf)
+        if not results or results[0].boxes is None:
+            return []
+
+        people = []
+        boxes = results[0].boxes
+        kps = results[0].keypoints
+
+        for i in range(len(boxes)):
+            x1, y1, x2, y2 = [int(v) for v in boxes.xyxy[i].tolist()]
+            box_conf = float(boxes.conf[i].item())
+
+            points = kps.xyn[i].cpu().numpy() if kps is not None else None
+            kp_conf = (
+                kps.conf[i].cpu().numpy()
+                if kps is not None and kps.conf is not None
+                else np.ones(17, dtype=np.float32)
+            )
+
+            people.append(
+                {
+                    "bbox": (x1, y1, x2, y2),
+                    "confidence": box_conf,
+                    "keypoints": points,
+                    "kp_conf": kp_conf,
+                }
+            )
+
+        return people
+
+    def is_waving_from_keypoints(self, points, conf):
+        """Check if person has a hand raised using pre-computed keypoints."""
+        if points is None:
+            return False
+
+        left_raised = (
+            points[LEFT_WRIST][1] < points[LEFT_SHOULDER][1]
+            or points[LEFT_ELBOW][1] < points[LEFT_SHOULDER][1]
+        )
+        right_raised = (
+            points[RIGHT_WRIST][1] < points[RIGHT_SHOULDER][1]
+            or points[RIGHT_ELBOW][1] < points[RIGHT_SHOULDER][1]
+        )
+        return left_raised or right_raised
+
+    def is_sitting_from_keypoints(self, points, scores):
+        """Check sitting pose from pre-computed keypoints."""
+        keypoint_score = 0.2
+        knee_max_angle = 120.0
+        hip_max_angle = 150.0
+        keypoints = {
+            "shoulder_l": 5,
+            "shoulder_r": 6,
+            "hip_l": 11,
+            "hip_r": 12,
+            "knee_l": 13,
+            "knee_r": 14,
+            "ankle_l": 15,
+            "ankle_r": 16,
+        }
+        for side in ("l", "r"):
+            if self._is_sitting_side(
+                points,
+                scores,
+                side,
+                keypoints,
+                keypoint_score,
+                knee_max_angle,
+                hip_max_angle,
+            ):
+                return True
+        return False
+
     # ── Core keypoint extraction ──
 
     def _get_keypoints(self, image):
@@ -143,26 +221,6 @@ class PoseDetection:
             gesture = Gestures.WAVING
 
         return gesture
-
-    def is_waving_customer(self, image):
-        """Check if person has one hand raised (waving)."""
-        points, conf = self._get_keypoints(image)
-        if points is None:
-            return False
-        try:
-            if (
-                points[RIGHT_WRIST][1] < points[RIGHT_SHOULDER][1]
-                and points[LEFT_WRIST][1] > points[LEFT_SHOULDER][1]
-            ):
-                return True
-            if (
-                points[LEFT_WRIST][1] < points[LEFT_SHOULDER][1]
-                and points[RIGHT_WRIST][1] > points[RIGHT_SHOULDER][1]
-            ):
-                return True
-            return False
-        except Exception:
-            return False
 
     # ── Gesture sub-checks ──
 
@@ -279,56 +337,6 @@ class PoseDetection:
         knee_angle = self._joint_angle_vectors(hip - knee, ankle - knee)
         hip_angle = self._joint_angle_vectors(torso_vec, knee - hip)
         return knee_angle <= knee_max_angle and hip_angle <= hip_max_angle
-
-    def _get_pose_points_scores(self, image):
-        results = self.yolo_pose(image, verbose=False)
-        if (
-            not results
-            or results[0].keypoints is None
-            or results[0].keypoints.xy is None
-        ):
-            return None, None
-        points_batch = results[0].keypoints.xy.cpu().numpy()
-        scores_batch = (
-            results[0].keypoints.conf.cpu().numpy()
-            if results[0].keypoints.conf is not None
-            else np.ones(points_batch.shape[:2], dtype=np.float32)
-        )
-        return points_batch, scores_batch
-
-    def is_sitting_yolo(self, image):
-        """Detect sitting pose using YOLO pose keypoints."""
-        keypoint_score = 0.2
-        knee_max_angle = 120.0
-        hip_max_angle = 150.0
-        keypoints = {
-            "shoulder_l": 5,
-            "shoulder_r": 6,
-            "hip_l": 11,
-            "hip_r": 12,
-            "knee_l": 13,
-            "knee_r": 14,
-            "ankle_l": 15,
-            "ankle_r": 16,
-        }
-
-        points_batch, scores_batch = self._get_pose_points_scores(image)
-        if points_batch is None:
-            return False
-
-        for points, scores in zip(points_batch, scores_batch):
-            for side in ("l", "r"):
-                if self._is_sitting_side(
-                    points,
-                    scores,
-                    side,
-                    keypoints,
-                    keypoint_score,
-                    knee_max_angle,
-                    hip_max_angle,
-                ):
-                    return True
-        return False
 
     # ── Person orientation ──
 

--- a/vision/packages/vision_general/scripts/pose_detection.py
+++ b/vision/packages/vision_general/scripts/pose_detection.py
@@ -92,12 +92,18 @@ class PoseDetection:
             return False
 
         left_raised = (
-            points[LEFT_WRIST][1] < points[LEFT_SHOULDER][1]
-            or points[LEFT_ELBOW][1] < points[LEFT_SHOULDER][1]
+            conf[LEFT_WRIST] > KP_CONF
+            and points[LEFT_WRIST][1] < points[LEFT_SHOULDER][1]
+        ) or (
+            conf[LEFT_ELBOW] > KP_CONF
+            and points[LEFT_ELBOW][1] < points[LEFT_SHOULDER][1]
         )
         right_raised = (
-            points[RIGHT_WRIST][1] < points[RIGHT_SHOULDER][1]
-            or points[RIGHT_ELBOW][1] < points[RIGHT_SHOULDER][1]
+            conf[RIGHT_WRIST] > KP_CONF
+            and points[RIGHT_WRIST][1] < points[RIGHT_SHOULDER][1]
+        ) or (
+            conf[RIGHT_ELBOW] > KP_CONF
+            and points[RIGHT_ELBOW][1] < points[RIGHT_SHOULDER][1]
         )
         return left_raised or right_raised
 

--- a/vision/packages/vision_general/scripts/tracker_node.py
+++ b/vision/packages/vision_general/scripts/tracker_node.py
@@ -322,9 +322,10 @@ class SingleTracker(Node):
                             response_clean = response_q.strip()
 
                     if value == "wavingCustomer":
-                        raising = self.pose_detection.is_waving_customer(cropped_image)
+                        pts, kpc = self.pose_detection._get_keypoints(cropped_image)
+                        raising = self.pose_detection.is_waving_from_keypoints(pts, kpc)
                         if raising:
-                            print("IS RAISING HANDDDDDDDDDDDDDDDDDD")
+                            print("Is rising hand")
                             response_clean = value
 
                     if response_clean == value or response_clean == "1":


### PR DESCRIPTION
- Refactor customer_node: previously it ran a YOLO tracker (ByteTrack) every 100ms to get person bounding boxes,
  then cropped each person and ran YOLO pose separately on each crop. This was redundant (two YOLO passes) and the    
  tracker's smoothed bounding boxes would cut off raised hands, breaking waving detection. Now it runs YOLO pose once
  on the full image, getting both bounding boxes and keypoints in a single pass.   

 - fixing hand-raise detection 
<img width="686" height="421" alt="Screenshot from 2026-04-02 00-34-14" src="https://github.com/user-attachments/assets/7b7b8950-cd73-4d86-af53-28e09c7b12e1" />
<img width="697" height="394" alt="Screenshot from 2026-04-02 00-31-41" src="https://github.com/user-attachments/assets/5d0825b8-3477-49d3-b08b-4281854e4230" />
<img width="697" height="394" alt="Screenshot from 2026-04-02 00-17-49" src="https://github.com/user-attachments/assets/1715fb74-1a90-4ec2-9656-b36ce0baca34" />
<img width="697" height="394" alt="Screenshot from 2026-04-02 00-17-19" src="https://github.com/user-attachments/assets/0298af58-9feb-4d09-889d-259baeac508d" />
<img width="697" height="394" alt="Screenshot from 2026-04-02 00-16-50" src="https://github.com/user-attachments/assets/585af432-4f4f-4904-b39a-69c3a931455c" />
<img width="697" height="394" alt="Screenshot from 2026-04-02 00-16-28" src="https://github.com/user-attachments/assets/a4f31175-bc2b-4618-a5a1-d6749749231d" />

