### PR TITLE
feat: Add pre-commit hook and GitHub workflow (xarm_ros2)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Pre-commit hook: blocks accidental changes to the xarm_ros2 submodule.
+# To intentionally update the submodule, run:
+#   ALLOW_SUBMODULE_CHANGE=1 git commit ...
+#
+
+SUBMODULE_PATH="manipulation/packages/xarm_ros2"
+
+if git diff --cached --name-only | grep -q "^${SUBMODULE_PATH}$"; then
+    if [ "${ALLOW_SUBMODULE_CHANGE}" = "1" ]; then
+        echo "[pre-commit] xarm_ros2 submodule change allowed (ALLOW_SUBMODULE_CHANGE=1)"
+        exit 0
+    fi
+
+    echo ""
+    echo "============================================================"
+    echo " BLOCKED: xarm_ros2 submodule pointer was modified"
+    echo "============================================================"
+    echo ""
+    echo " You are about to commit a change to:"
+    echo "   ${SUBMODULE_PATH}"
+    echo ""
+    echo " This is usually accidental (e.g. running git add -A after"
+    echo " cd-ing into the submodule). Changing the submodule pointer"
+    echo " affects everyone on the team."
+    echo ""
+    echo " If this is intentional, re-run with:"
+    echo "   ALLOW_SUBMODULE_CHANGE=1 git commit ..."
+    echo ""
+    echo " To undo the staged change:"
+    echo "   git restore --staged ${SUBMODULE_PATH}"
+    echo "============================================================"
+    echo ""
+    exit 1
+fi

--- a/.github/workflows/check-submodules.yml
+++ b/.github/workflows/check-submodules.yml
@@ -1,0 +1,67 @@
+name: Check Submodule Integrity
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-xarm-submodule:
+    name: Verify xarm_ros2 submodule
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+          fetch-depth: 0
+
+      - name: Check xarm_ros2 submodule commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SUBMODULE_PATH="manipulation/packages/xarm_ros2"
+          EXPECTED_REMOTE="https://github.com/RoBorregos/xarm_ros2.git"
+          EXPECTED_BRANCH="xarm_servicios_estable"
+
+          # Get the submodule commit pointer from this PR
+          SUBMODULE_COMMIT=$(git ls-tree HEAD "$SUBMODULE_PATH" | awk '{print $3}')
+
+          if [ -z "$SUBMODULE_COMMIT" ]; then
+            echo "::warning::Submodule ${SUBMODULE_PATH} not found in tree — skipping check."
+            exit 0
+          fi
+
+          echo "Submodule commit: ${SUBMODULE_COMMIT}"
+          echo "Expected remote:  ${EXPECTED_REMOTE}"
+          echo "Expected branch:  ${EXPECTED_BRANCH}"
+
+          # Clone only the expected branch (shallow) and check if the commit exists
+          git clone --bare --single-branch --branch "$EXPECTED_BRANCH" "$EXPECTED_REMOTE" /tmp/xarm_ros2_check
+
+          if git -C /tmp/xarm_ros2_check cat-file -e "${SUBMODULE_COMMIT}^{commit}" 2>/dev/null; then
+            # Verify the commit is reachable from the branch tip
+            BRANCH_TIP=$(git -C /tmp/xarm_ros2_check rev-parse "refs/heads/${EXPECTED_BRANCH}")
+            if git -C /tmp/xarm_ros2_check merge-base --is-ancestor "${SUBMODULE_COMMIT}" "${BRANCH_TIP}" 2>/dev/null; then
+              echo "✅ Submodule commit ${SUBMODULE_COMMIT:0:12} is on branch ${EXPECTED_BRANCH}"
+              exit 0
+            fi
+          fi
+
+          echo ""
+          echo "============================================================"
+          echo " ❌ xarm_ros2 submodule points to an invalid commit"
+          echo "============================================================"
+          echo ""
+          echo " Commit ${SUBMODULE_COMMIT:0:12} is NOT on branch"
+          echo " '${EXPECTED_BRANCH}' of ${EXPECTED_REMOTE}"
+          echo ""
+          echo " This usually means someone accidentally changed the"
+          echo " submodule pointer. To fix it:"
+          echo ""
+          echo "   git submodule update --init ${SUBMODULE_PATH}"
+          echo "   git add ${SUBMODULE_PATH}"
+          echo "   git commit --amend"
+          echo ""
+          echo "============================================================"
+          exit 1


### PR DESCRIPTION
## Add submodule protection for xarm_ros2

Prevents accidental submodule pointer changes that cause 
xarm_msgs type hash mismatches across containers.

### Changes
- `.githooks/pre-commit`: Blocks commits that modify xarm_ros2 submodule (bypass with ALLOW_SUBMODULE_CHANGE=1)
- `.github/workflows/check-submodules.yml`: CI check on PRs to main — verifies submodule commit is on the expected branch (xarm_servicios_estable)

### Setup
After cloning, run: `git config core.hooksPath .githooks`