### PR TITLE
Refactor manipulation run.sh to use common flag parsing

### DIFF
--- a/docker/manipulation/run.sh
+++ b/docker/manipulation/run.sh
@@ -7,69 +7,12 @@ ARGS=("$@")  # Save all arguments in an array
 TASK=${ARGS[0]}
 ENV_TYPE="${*: -1}"
 
-# IMPORTANT: Also edit auto-complete.sh to add new arguments
-DETACHED=""
-BUILD=""
-BUILD_IMAGE=""
-UPLOAD_IMAGE=""
-CLEAN=""
-
 COMPOSE="docker-compose-${ENV_TYPE}.yaml"
-
-# Parse arguments
-for arg in "${ARGS[@]}"; do
-    case $arg in
-    "-d")
-        DETACHED="-d"
-        ;;
-    "--build")
-        BUILD="true"
-        ;;
-    "--recreate")
-        docker compose -f "$COMPOSE" down
-        ;;
-    "--down")
-        docker compose -f "$COMPOSE" down
-        exit 0
-        ;;
-    "--stop")
-        docker compose -f "$COMPOSE" stop
-        exit 0
-        ;;
-    "--build-image")
-        BUILD_IMAGE="--build"
-        ;;
-    "--upload-image")
-        UPLOAD_IMAGE="true"
-        ;;
-    "--clean")
-        CLEAN="true"
-        ;;
-    esac
-done
+parse_common_flags "$COMPOSE" "${ARGS[@]}"
 
 #_________________________SETUP_________________________
 
-# Reset .env
-echo "" > .env
-
-# CycloneDDS interface from host
-if [ -f /etc/cyclonedds.env ]; then
-    source /etc/cyclonedds.env
-fi
-add_or_update_variable .env "CYCLONE_INTERFACE" "${CYCLONE_INTERFACE:-}"
-
-# Export user
-add_or_update_variable .env "LOCAL_USER_ID" "$(id -u)"
-add_or_update_variable .env "LOCAL_GROUP_ID" "$(id -g)"
-
-# Clean build artifacts if requested
-if [ "$CLEAN" == "true" ]; then
-  clean_directories .
-fi
-
-# Create dirs with current user to avoid permission problems
-mkdir -p install build log
+setup_common_env "manipulation"
 
 #_________________________RUN_________________________
 


### PR DESCRIPTION
## Summary
- Replace duplicated boilerplate in `docker/manipulation/run.sh` with `parse_common_flags` and `setup_common_env` from `lib.sh`
- Same pattern as PR #775 for HRI
- No behavior changes — all flags work exactly the same

## Test plan
- [x] `./run.sh manipulation --build --recreate` works
- [x] `./run.sh manipulation --down` works
- [x] `./run.sh manipulation -d` works