### PR TITLE
fix(manipulation/run.sh): include xarm6_ikfast_plugin in colcon build

### DIFF
--- a/docker/manipulation/run.sh
+++ b/docker/manipulation/run.sh
@@ -22,7 +22,7 @@ SOURCE_INTERFACES="if [ -f frida_interfaces_cache/install/local_setup.bash ]; th
 GPD_SETUP=". /home/ros/setup_gpd.sh"
 GPD_EXPORT="export GPD_INSTALL_DIR=/workspace/install/gpd"
 SOURCE="if [ -f install/setup.bash ]; then source install/setup.bash; fi"
-COLCON="colcon build --symlink-install --packages-up-to manipulation_general --packages-ignore realsense_gazebo_plugin xarm_gazebo frida_interfaces"
+COLCON="colcon build --symlink-install --packages-up-to manipulation_general xarm6_ikfast_plugin --packages-ignore realsense_gazebo_plugin xarm_gazebo frida_interfaces"
 CYCLONE_SOURCE="source /usr/local/bin/cyclonedds_setup.sh"
 
 if [ "$BUILD" == "true" ]; then


### PR DESCRIPTION
## Summary

- The manipulation container's colcon build command uses `--packages-up-to manipulation_general`, which only compiles `manipulation_general` and its declared `package.xml` dependencies.
- `xarm6_ikfast_plugin` is loaded by MoveIt at runtime via pluginlib and is **not declared as a package dependency anywhere**, so colcon silently skips it.
- Result: `libxarm6_ikfast_plugin.so` is absent from the install tree, and when `move_group` starts it cannot load the kinematics solver declared in `xarm_moveit_config/config/xarm6/kinematics.yaml` (`xarm6_ikfast_plugin/IKFastKinematicsPlugin`). MoveIt either falls back to KDL silently or fails to load the xarm6 group solver — xarm6 planning ends up on the slower numerical KDL solver instead of the analytical IKFast plugin that xarm_ros2 was configured to use.

## Fix

Add `xarm6_ikfast_plugin` explicitly to `--packages-up-to` so colcon builds the plugin every time the manipulation image is rebuilt.

## Verification

Verified on both Orins (integration + manipulation) after rebuild:

- `libxarm6_ikfast_plugin.so` produced in `/workspace/install/xarm6_ikfast_plugin/lib/`
- `ikfast_plugin_description.xml` installed in `share/`
- pluginlib resource registered: `share/ament_index/resource_index/moveit_core__pluginlib__plugin/xarm6_ikfast_plugin`
- Plugin class `xarm6_ikfast_plugin/IKFastKinematicsPlugin` correctly declares base class `kinematics::KinematicsBase` (what MoveIt's kinematics loader looks for).

## Follow-up

A cleaner long-term fix would be to add `<depend>xarm6_ikfast_plugin</depend>` to `manipulation_general` or `arm_pkg` `package.xml` so that the dependency is expressed properly and any `colcon build` invocation picks it up — not just invocations through `docker/manipulation/run.sh`. Leaving that out of this PR to keep the change minimal.

## Test plan

- [ ] `./run.sh manipulation --build --recreate` on the manipulation Orin completes without errors
- [ ] `find /workspace/install -name 'libxarm6_ikfast_plugin*'` returns the .so after build
- [ ] After launching manipulation, `ros2 param get /move_group robot_description_kinematics.xarm6.kinematics_solver` returns `xarm6_ikfast_plugin/IKFastKinematicsPlugin`
- [ ] Arm planning with RRTConnect is noticeably faster (IKFast ~5µs vs KDL slow failure-prone range)