### PR TITLE
Vision/orientation node

### DIFF
--- a/frida_constants/frida_constants/vision_constants.py
+++ b/frida_constants/frida_constants/vision_constants.py
@@ -106,8 +106,11 @@ FOLLOW_TOPIC = "/vision/follow_face"
 PERSON_LIST_TOPIC = "/vision/person_list"
 PERSON_NAME_TOPIC = "/vision/person_detected_name"
 FACE_RECOGNITION_IMAGE = "/vision/face_recognition_image"
-FLIP_IMAGE_TOPIC = "/vision/face_recognition/flip_image"
 FOLLOW_BY_TOPIC = "/vision/follow_by_name"
+
+# Camera orientation (centralized flip/rotation handling)
+IMAGE_ORIENTED_TOPIC = "/vision/camera/image_oriented"
+CAMERA_ROTATION_TOPIC = "/vision/camera/rotation"
 
 # HRIC commands node
 CHECK_PERSON_TOPIC = "/vision/hric/detect_person"

--- a/task_manager/scripts/test/test_vision_manager.py
+++ b/task_manager/scripts/test/test_vision_manager.py
@@ -7,8 +7,9 @@ Task Manager for testing the vision subtask manager
 import rclpy
 from geometry_msgs.msg import Point
 from rclpy.node import Node
+from visualization_msgs.msg import Marker
 
-from frida_constants.vision_constants import FOLLOW_TOPIC
+from frida_constants.vision_constants import CAMERA_FRAME, FOLLOW_TOPIC
 from task_manager.subtask_managers.vision_tasks import VisionTasks
 from task_manager.utils.logger import Logger
 from task_manager.utils.status import Status
@@ -22,8 +23,11 @@ TEST_MOONDREAM_QUERY = False
 TEST_FIND_SEAT = False
 TEST_GET_PERSON_NAME = False
 TEST_FOLLOW_FACE = False
+TEST_HAND_MARKER = False
 
 FOLLOW_FACE_FLIP = False
+HAND_MARKER_FLIP = False
+HAND_MARKER_TOPIC = "/vision/test/hand_marker"
 
 
 class TestVisionManager(Node):
@@ -55,6 +59,9 @@ class TestVisionManager(Node):
 
         if TEST_FOLLOW_FACE:
             self.test_follow_face()
+
+        if TEST_HAND_MARKER:
+            self.test_hand_marker()
 
         exit(0)
 
@@ -159,6 +166,51 @@ class TestVisionManager(Node):
             self.vision_manager.camera_upside_down(False)
             self.vision_manager.deactivate_face_recognition()
             Logger.info(self, f"follow_face test stopped ({count[0]} messages)")
+
+    def test_hand_marker(self):
+        """Continuously call detect_hand and publish its 3D point as a Marker
+        in CAMERA_FRAME so it can be visualized in rviz. HAND_MARKER_FLIP
+        controls whether the camera runs flipped (180°) or normal.
+        """
+        Logger.info(self, "=== Testing hand marker ===")
+
+        marker_pub = self.create_publisher(Marker, HAND_MARKER_TOPIC, 10)
+        self.vision_manager.camera_upside_down(HAND_MARKER_FLIP)
+        Logger.info(
+            self,
+            f"Extend your hand in front of the camera. flip={HAND_MARKER_FLIP}. "
+            f"Marker on '{HAND_MARKER_TOPIC}'. Ctrl+C to stop.",
+        )
+
+        try:
+            while rclpy.ok():
+                rclpy.spin_once(self, timeout_sec=0.05)
+                status, point = self.vision_manager.detect_hand()
+                if status != Status.EXECUTION_SUCCESS or point is None:
+                    continue
+
+                marker = Marker()
+                marker.header.frame_id = CAMERA_FRAME
+                marker.header.stamp = self.get_clock().now().to_msg()
+                marker.ns = "hand_marker_test"
+                marker.id = 0
+                marker.type = Marker.SPHERE
+                marker.action = Marker.ADD
+                marker.pose.position = point.point
+                marker.pose.orientation.w = 1.0
+                marker.scale.x = 0.08
+                marker.scale.y = 0.08
+                marker.scale.z = 0.08
+                marker.color.r = 0.0
+                marker.color.g = 1.0
+                marker.color.b = 0.0
+                marker.color.a = 1.0
+                marker_pub.publish(marker)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.vision_manager.camera_upside_down(False)
+            Logger.info(self, "hand marker test stopped")
 
 
 def main(args=None):

--- a/task_manager/scripts/test/test_vision_manager.py
+++ b/task_manager/scripts/test/test_vision_manager.py
@@ -5,20 +5,25 @@ Task Manager for testing the vision subtask manager
 """
 
 import rclpy
+from geometry_msgs.msg import Point
 from rclpy.node import Node
 
+from frida_constants.vision_constants import FOLLOW_TOPIC
 from task_manager.subtask_managers.vision_tasks import VisionTasks
-from task_manager.utils.task import Task
 from task_manager.utils.logger import Logger
 from task_manager.utils.status import Status
+from task_manager.utils.task import Task
 
 # Choose which tests to perform
 TEST_DETECT_OBJECTS = False
 TEST_DETECT_PERSON = False
-TEST_CUSTOMER_TABLES = True
+TEST_CUSTOMER_TABLES = False
 TEST_MOONDREAM_QUERY = False
 TEST_FIND_SEAT = False
 TEST_GET_PERSON_NAME = False
+TEST_FOLLOW_FACE = False
+
+FOLLOW_FACE_FLIP = False
 
 
 class TestVisionManager(Node):
@@ -47,6 +52,9 @@ class TestVisionManager(Node):
 
         if TEST_GET_PERSON_NAME:
             self.test_get_person_name()
+
+        if TEST_FOLLOW_FACE:
+            self.test_follow_face()
 
         exit(0)
 
@@ -122,6 +130,35 @@ class TestVisionManager(Node):
         else:
             Logger.warn(self, "No person name detected")
         self.vision_manager.deactivate_face_recognition()
+
+    def test_follow_face(self):
+        """Subscribe to the follow_face Point and log each incoming angular
+        delta while face recognition is active. FOLLOW_FACE_FLIP controls
+        whether the camera runs flipped (180°) or normal (0°).
+        """
+        Logger.info(self, "=== Testing follow_face ===")
+
+        count = [0]
+
+        def cb(msg: Point):
+            count[0] += 1
+            Logger.info(self, f"follow_face  x={msg.x:+.3f}  y={msg.y:+.3f}  (msg #{count[0]})")
+
+        self.create_subscription(Point, FOLLOW_TOPIC, cb, 10)
+        self.vision_manager.activate_face_recognition()
+        self.vision_manager.follow_by_name("area")
+        self.vision_manager.camera_upside_down(FOLLOW_FACE_FLIP)
+        Logger.info(self, f"Move your face. flip={FOLLOW_FACE_FLIP}. Ctrl+C to stop.")
+
+        try:
+            while rclpy.ok():
+                rclpy.spin_once(self, timeout_sec=0.1)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.vision_manager.camera_upside_down(False)
+            self.vision_manager.deactivate_face_recognition()
+            Logger.info(self, f"follow_face test stopped ({count[0]} messages)")
 
 
 def main(args=None):

--- a/task_manager/task_manager/subtask_managers/vision_tasks.py
+++ b/task_manager/task_manager/subtask_managers/vision_tasks.py
@@ -34,7 +34,7 @@ from frida_constants.vision_constants import (
     SET_TARGET_TOPIC,
     SHELF_DETECTION_TOPIC,
     DETECT_HAND_SERVICE,
-    FLIP_IMAGE_TOPIC,
+    CAMERA_ROTATION_TOPIC,
 )
 from frida_interfaces.action import DetectPerson
 from frida_interfaces.msg import ObjectDetection, PersonList
@@ -60,6 +60,7 @@ from rclpy.action import ActionClient
 from rclpy.node import Node
 from std_msgs.msg import String
 from std_msgs.msg import Bool as BoolMsg
+from std_msgs.msg import Int8
 from std_srvs.srv import SetBool, Trigger
 from task_manager.utils.decorators import mockable, service_check
 from task_manager.utils.logger import Logger
@@ -96,7 +97,7 @@ class VisionTasks:
         self.person_list = []
         self.person_name = ""
 
-        self.rotate_camera_publisher = self.node.create_publisher(BoolMsg, FLIP_IMAGE_TOPIC, 10)
+        self.rotate_camera_publisher = self.node.create_publisher(Int8, CAMERA_ROTATION_TOPIC, 10)
         self.face_subscriber = self.node.create_subscription(
             Point, FOLLOW_TOPIC, self.follow_callback, 10
         )
@@ -1039,9 +1040,18 @@ class VisionTasks:
 
         return Status.EXECUTION_SUCCESS, location
 
-    def camera_upside_down(self, flip: bool):
-        msg = BoolMsg()
-        msg.data = flip
+    def camera_upside_down(self, flip):
+        """Publish the camera rotation on CAMERA_ROTATION_TOPIC.
+
+        Accepts either a bool (True -> 180, False -> 0) for backward
+        compatibility, or an int in {0, 90, 180, 270} for explicit rotation.
+        """
+        if isinstance(flip, bool):
+            rotation = 180 if flip else 0
+        else:
+            rotation = int(flip) % 360
+        msg = Int8()
+        msg.data = rotation
         self.rotate_camera_publisher.publish(msg)
 
 

--- a/task_manager/task_manager/subtask_managers/vision_tasks.py
+++ b/task_manager/task_manager/subtask_managers/vision_tasks.py
@@ -60,7 +60,7 @@ from rclpy.action import ActionClient
 from rclpy.node import Node
 from std_msgs.msg import String
 from std_msgs.msg import Bool as BoolMsg
-from std_msgs.msg import Int8
+from std_msgs.msg import Int16
 from std_srvs.srv import SetBool, Trigger
 from task_manager.utils.decorators import mockable, service_check
 from task_manager.utils.logger import Logger
@@ -97,7 +97,7 @@ class VisionTasks:
         self.person_list = []
         self.person_name = ""
 
-        self.rotate_camera_publisher = self.node.create_publisher(Int8, CAMERA_ROTATION_TOPIC, 10)
+        self.rotate_camera_publisher = self.node.create_publisher(Int16, CAMERA_ROTATION_TOPIC, 10)
         self.face_subscriber = self.node.create_subscription(
             Point, FOLLOW_TOPIC, self.follow_callback, 10
         )
@@ -1050,7 +1050,7 @@ class VisionTasks:
             rotation = 180 if flip else 0
         else:
             rotation = int(flip) % 360
-        msg = Int8()
+        msg = Int16()
         msg.data = rotation
         self.rotate_camera_publisher.publish(msg)
 

--- a/vision/packages/vision_general/launch/gpsr_launch.py
+++ b/vision/packages/vision_general/launch/gpsr_launch.py
@@ -18,6 +18,13 @@ def generate_launch_description():
         [
             Node(
                 package="vision_general",
+                executable="image_orienter.py",
+                name="image_orienter",
+                output="screen",
+                emulate_tty=True,
+            ),
+            Node(
+                package="vision_general",
                 executable="yolo_node.py",
                 name="yolo_node",
                 output="screen",

--- a/vision/packages/vision_general/launch/hric_launch.py
+++ b/vision/packages/vision_general/launch/hric_launch.py
@@ -7,6 +7,13 @@ def generate_launch_description():
         [
             Node(
                 package="vision_general",
+                executable="image_orienter.py",
+                name="image_orienter",
+                output="screen",
+                emulate_tty=True,
+            ),
+            Node(
+                package="vision_general",
                 executable="face_recognition_node.py",
                 name="face_recognition",
                 output="screen",

--- a/vision/packages/vision_general/launch/ppc_launch.py
+++ b/vision/packages/vision_general/launch/ppc_launch.py
@@ -17,6 +17,13 @@ def generate_launch_description():
         [
             Node(
                 package="vision_general",
+                executable="image_orienter.py",
+                name="image_orienter",
+                output="screen",
+                emulate_tty=True,
+            ),
+            Node(
+                package="vision_general",
                 executable="yolo_node.py",
                 name="yolo_node",
                 output="screen",

--- a/vision/packages/vision_general/scripts/face_recognition_node.py
+++ b/vision/packages/vision_general/scripts/face_recognition_node.py
@@ -26,23 +26,17 @@ from std_msgs.msg import Bool, String
 
 from frida_constants.vision_constants import (
     CAMERA_INFO_TOPIC,
-    CAMERA_TOPIC,
     DEPTH_IMAGE_TOPIC,
     FACE_RECOGNITION_IMAGE,
-    FLIP_IMAGE_TOPIC,
     FOLLOW_BY_TOPIC,
     FOLLOW_TOPIC,
+    IMAGE_ORIENTED_TOPIC,
     PERSON_LIST_TOPIC,
     PERSON_NAME_TOPIC,
     SAVE_NAME_TOPIC,
 )
 from frida_interfaces.msg import Person, PersonList
 from frida_interfaces.srv import SaveName
-
-# from vision_general.utils.calculations import (
-#     get_depth,
-#     deproject_pixel_to_point,
-# )
 
 
 DEFAULT_NAME = "ale"
@@ -70,7 +64,7 @@ class FaceRecognition(Node):
 
         self.image_subscriber = self.create_subscription(
             Image,
-            CAMERA_TOPIC,
+            IMAGE_ORIENTED_TOPIC,
             self.image_callback,
             self._img_qos,
             callback_group=self.callback_group,
@@ -113,18 +107,10 @@ class FaceRecognition(Node):
         self.annotated_frame = []
         self.vision_active = True
         self.is_processing = False
-        self.flip_image = False
         self.create_subscription(
             Bool,
             "/vision/face_recognition/active",
             self._active_callback,
-            10,
-            callback_group=self.callback_group,
-        )
-        self.create_subscription(
-            Bool,
-            FLIP_IMAGE_TOPIC,
-            self._flip_callback,
             10,
             callback_group=self.callback_group,
         )
@@ -294,13 +280,6 @@ class FaceRecognition(Node):
 
         target = Point()
 
-        # if len(self.depth_image) > 0:
-        #     point2D = (xc, yc)
-        #     depth = get_depth(self.depth_image, point2D)
-        #     point3D = deproject_pixel_to_point(self.imageInfo, point2D, depth)
-        #     point3D = float(point3D[0]), float(point3D[1]), float(point3D[2])
-        #     target.z = point3D[2]
-
         target.x = move_x
         target.y = move_y
 
@@ -317,11 +296,6 @@ class FaceRecognition(Node):
             return
         self.vision_active = msg.data
         self.get_logger().info(f"Face recognition active: {self.vision_active}")
-
-    def _flip_callback(self, msg):
-        if msg.data != self.flip_image:
-            self.flip_image = msg.data
-            self.get_logger().info(f"Flip image set to: {self.flip_image}")
 
     def run(self) -> None:
         """Run face recognition algorithm"""
@@ -352,8 +326,6 @@ class FaceRecognition(Node):
         self.processing_id = self.id
 
         self.frame = self.image
-        if self.flip_image:
-            self.frame = cv2.rotate(self.frame, cv2.ROTATE_180)
         self.annotated_frame = self.frame.copy()
         self.center = [self.frame.shape[1] / 2, self.frame.shape[0] / 2]
 
@@ -507,15 +479,7 @@ class FaceRecognition(Node):
             self.publish_follow_face(xc, yc, largest_face_name)
         else:
             self.name_publisher.publish(String(data=""))
-        # if self.verbose:
-        #    cv2.imshow("Face recognition", self.annotated_frame)
-        # self.image_view = self.annotated_frame
-        # self.view_pub.publish(
-        #     self.bridge.cv2_to_imgmsg(self.self.annotated_frame, "bgr8")
-        # )
 
-        # if cv2.waitKey(1) & 0xFF == ord("q"):
-        #     self.prev_faces = []
         self.publish_image()
 
 

--- a/vision/packages/vision_general/scripts/hric_commands.py
+++ b/vision/packages/vision_general/scripts/hric_commands.py
@@ -18,7 +18,7 @@ from sensor_msgs.msg import Image, CameraInfo
 from builtin_interfaces.msg import Time
 from rclpy.task import Future
 from vision_general.utils.trt_utils import load_yolo_trt
-from std_msgs.msg import Int8
+from std_msgs.msg import Int16
 
 from frida_interfaces.action import DetectPerson
 from frida_interfaces.srv import DetectHand, FindSeat, YoloDetect
@@ -90,7 +90,7 @@ class HRICCommands(Node):
             callback_group=self.callback_group,
         )
         self.create_subscription(
-            Int8,
+            Int16,
             CAMERA_ROTATION_TOPIC,
             self._rotation_callback,
             10,

--- a/vision/packages/vision_general/scripts/hric_commands.py
+++ b/vision/packages/vision_general/scripts/hric_commands.py
@@ -18,18 +18,20 @@ from sensor_msgs.msg import Image, CameraInfo
 from builtin_interfaces.msg import Time
 from rclpy.task import Future
 from vision_general.utils.trt_utils import load_yolo_trt
+from std_msgs.msg import Int8
 
 from frida_interfaces.action import DetectPerson
 from frida_interfaces.srv import DetectHand, FindSeat, YoloDetect
 from vision_general.utils.calculations import point2d_to_ros_point_stamped
 from frida_constants.vision_constants import (
-    CAMERA_TOPIC,
+    CAMERA_ROTATION_TOPIC,
     CAMERA_FRAME,
     CAMERA_INFO_TOPIC,
     CHECK_PERSON_TOPIC,
     DEPTH_IMAGE_TOPIC,
     DETECT_HAND_SERVICE,
     FIND_SEAT_TOPIC,
+    IMAGE_ORIENTED_TOPIC,
     IMAGE_TOPIC_HRIC,
     YOLO_DETECTION_TOPIC,
 )
@@ -68,7 +70,7 @@ class HRICCommands(Node):
         )
         self.create_subscription(
             Image,
-            CAMERA_TOPIC,
+            IMAGE_ORIENTED_TOPIC,
             self.image_callback,
             self._img_qos,
             callback_group=self.callback_group,
@@ -85,6 +87,13 @@ class HRICCommands(Node):
             CAMERA_INFO_TOPIC,
             self.camera_info_callback,
             self._img_qos,
+            callback_group=self.callback_group,
+        )
+        self.create_subscription(
+            Int8,
+            CAMERA_ROTATION_TOPIC,
+            self._rotation_callback,
+            10,
             callback_group=self.callback_group,
         )
 
@@ -117,6 +126,7 @@ class HRICCommands(Node):
         self.camera_info = None
         self.output_image = []
         self.check = False
+        self.rotation = 0
 
         # YOLO pose replaces mediapipe Hands — wrist keypoints as hand proxy
         self.pose_model = _load_yolo_pose("yolo11m-pose.pt")
@@ -131,6 +141,12 @@ class HRICCommands(Node):
         self.get_logger().info("HRIC Commands Ready.")
 
         self.create_timer(0.1, self.publish_image, callback_group=self.callback_group)
+
+    def _rotation_callback(self, msg):
+        value = int(msg.data) % 360
+        if value != self.rotation:
+            self.rotation = value
+            self.get_logger().info(f"Camera rotation set to {self.rotation}")
 
     def image_callback(self, data):
         """Callback to receive the image from the camera."""
@@ -189,8 +205,7 @@ class HRICCommands(Node):
             return None
 
         if self.depth_image is not None and self.camera_info is not None:
-            # Scale wrist pixel from YOLO image resolution to camera_info resolution,
-            # same convention used in restaurant_commands.py
+            # Scale wrist pixel from YOLO image resolution to camera_info resolution.
             cam_w = self.camera_info.width
             cam_h = self.camera_info.height
             px_ci = int(cx * cam_w / w)
@@ -202,6 +217,7 @@ class HRICCommands(Node):
                 (px_ci, py_ci),
                 CAMERA_FRAME,
                 Time(sec=0, nanosec=0),
+                rotation=self.rotation,
             )
             return stamped
         else:

--- a/vision/packages/vision_general/scripts/hric_commands.py
+++ b/vision/packages/vision_general/scripts/hric_commands.py
@@ -205,16 +205,10 @@ class HRICCommands(Node):
             return None
 
         if self.depth_image is not None and self.camera_info is not None:
-            # Scale wrist pixel from YOLO image resolution to camera_info resolution.
-            cam_w = self.camera_info.width
-            cam_h = self.camera_info.height
-            px_ci = int(cx * cam_w / w)
-            py_ci = int(cy * cam_h / h)
-
             stamped = point2d_to_ros_point_stamped(
                 self.camera_info,
                 self.depth_image,
-                (px_ci, py_ci),
+                (cx, cy),
                 CAMERA_FRAME,
                 Time(sec=0, nanosec=0),
                 rotation=self.rotation,

--- a/vision/packages/vision_general/scripts/image_orienter.py
+++ b/vision/packages/vision_general/scripts/image_orienter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Republishes the camera image rotated by an Int8 (0/90/180/270) so 2D
+Republishes the camera image rotated by an Int16 (0/90/180/270) so 2D
 detectors consume an upright frame. Depth, camera_info and the TF tree
 are left untouched; detectors that need 3D must use raw depth and pass
 `rotation` to `point2d_to_ros_point_stamped`.
@@ -13,7 +13,7 @@ import rclpy.qos
 from cv_bridge import CvBridge
 from rclpy.node import Node
 from sensor_msgs.msg import Image
-from std_msgs.msg import Int8
+from std_msgs.msg import Int16
 
 from frida_constants.vision_constants import (
     CAMERA_ROTATION_TOPIC,
@@ -37,13 +37,13 @@ class ImageOrienter(Node):
         )
 
         self.create_subscription(Image, CAMERA_TOPIC, self._image_cb, img_qos)
-        self.create_subscription(Int8, CAMERA_ROTATION_TOPIC, self._rotation_cb, 10)
+        self.create_subscription(Int16, CAMERA_ROTATION_TOPIC, self._rotation_cb, 10)
 
         self.pub = self.create_publisher(Image, IMAGE_ORIENTED_TOPIC, img_qos)
 
         self.get_logger().info("Image orienter ready (rotation=0)")
 
-    def _rotation_cb(self, msg: Int8):
+    def _rotation_cb(self, msg: Int16):
         value = int(msg.data) % 360
         if value not in VALID_ROTATIONS:
             self.get_logger().warn(

--- a/vision/packages/vision_general/scripts/image_orienter.py
+++ b/vision/packages/vision_general/scripts/image_orienter.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+"""
+Republishes the camera image rotated by an Int8 (0/90/180/270) so 2D
+detectors consume an upright frame. Depth, camera_info and the TF tree
+are left untouched; detectors that need 3D must use raw depth and pass
+`rotation` to `point2d_to_ros_point_stamped`.
+"""
+
+import cv2
+import rclpy
+import rclpy.qos
+from cv_bridge import CvBridge
+from rclpy.node import Node
+from sensor_msgs.msg import Image
+from std_msgs.msg import Int8
+
+from frida_constants.vision_constants import (
+    CAMERA_ROTATION_TOPIC,
+    CAMERA_TOPIC,
+    IMAGE_ORIENTED_TOPIC,
+)
+
+VALID_ROTATIONS = {0, 90, 180, 270}
+
+
+class ImageOrienter(Node):
+    def __init__(self):
+        super().__init__("image_orienter")
+        self.bridge = CvBridge()
+        self.rotation = 0
+
+        img_qos = rclpy.qos.QoSProfile(
+            depth=1,
+            reliability=rclpy.qos.ReliabilityPolicy.BEST_EFFORT,
+            durability=rclpy.qos.DurabilityPolicy.VOLATILE,
+        )
+
+        self.create_subscription(Image, CAMERA_TOPIC, self._image_cb, img_qos)
+        self.create_subscription(Int8, CAMERA_ROTATION_TOPIC, self._rotation_cb, 10)
+
+        self.pub = self.create_publisher(Image, IMAGE_ORIENTED_TOPIC, img_qos)
+
+        self.get_logger().info("Image orienter ready (rotation=0)")
+
+    def _rotation_cb(self, msg: Int8):
+        value = int(msg.data) % 360
+        if value not in VALID_ROTATIONS:
+            self.get_logger().warn(
+                f"Ignoring unsupported rotation {msg.data}; expected one of {sorted(VALID_ROTATIONS)}"
+            )
+            return
+        if value == self.rotation:
+            return
+        self.rotation = value
+        self.get_logger().info(f"Camera rotation set to {self.rotation}")
+
+    def _image_cb(self, msg: Image):
+        if self.rotation == 0:
+            self.pub.publish(msg)
+            return
+        try:
+            frame = self.bridge.imgmsg_to_cv2(msg, "bgr8")
+        except Exception as e:
+            self.get_logger().error(f"Image conversion failed: {e}")
+            return
+
+        if self.rotation == 180:
+            frame = cv2.rotate(frame, cv2.ROTATE_180)
+        elif self.rotation == 90:
+            frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+        elif self.rotation == 270:
+            frame = cv2.rotate(frame, cv2.ROTATE_90_COUNTERCLOCKWISE)
+
+        out = self.bridge.cv2_to_imgmsg(frame, "bgr8")
+        out.header = msg.header
+        self.pub.publish(out)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = ImageOrienter()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/vision/packages/vision_general/scripts/yolo_node.py
+++ b/vision/packages/vision_general/scripts/yolo_node.py
@@ -14,7 +14,7 @@ from cv_bridge import CvBridge
 from sensor_msgs.msg import Image
 
 from frida_constants.vision_constants import (
-    CAMERA_TOPIC,
+    IMAGE_ORIENTED_TOPIC,
     YOLO_DETECTION_TOPIC,
     YOLO_DETECTIONS_PUBLISHER_TOPIC,
 )
@@ -48,7 +48,7 @@ class YoloNode(Node):
         )
 
         self.create_subscription(
-            Image, CAMERA_TOPIC, self._image_callback, self._img_qos
+            Image, IMAGE_ORIENTED_TOPIC, self._image_callback, self._img_qos
         )
 
         # Publisher for annotated image

--- a/vision/packages/vision_general/vision_general/utils/calculations.py
+++ b/vision/packages/vision_general/vision_general/utils/calculations.py
@@ -322,6 +322,23 @@ def point3d_to_ros_point_stamped(
     return point_stamped
 
 
+def unrotate_pixel(
+    pixel: tuple[int, int], rotation: int, width: int, height: int
+) -> tuple[int, int]:
+    """Inverse of cv2.rotate for valid rotations (0/90/180/270 deg)."""
+    px, py = pixel
+    rotation = int(rotation) % 360
+    if rotation == 0:
+        return px, py
+    if rotation == 180:
+        return width - 1 - px, height - 1 - py
+    if rotation == 90:
+        return py, height - 1 - px
+    if rotation == 270:
+        return width - 1 - py, px
+    raise ValueError(f"Unsupported rotation {rotation}; expected 0/90/180/270")
+
+
 def point2d_to_ros_point_stamped(
     image_info,
     depth_image,
@@ -329,12 +346,18 @@ def point2d_to_ros_point_stamped(
     frame_id: str,
     stamp,
     is_optical: bool = False,
+    rotation: int = 0,
 ) -> PointStamped:
     """
     Given 2D pixel coordinates (x, y), intrinsic camera info and a depth image,
     calculates the 3D position and directly returns a standard ROS PointStamped.
     The point is in the camera optical frame by default (is_optical=False means no extra conversion).
     Set is_optical=True only if you want to manually convert from optical to ROS base_link convention.
+
+    If `rotation` is nonzero, `point2d` is un-rotated first so it indexes
+    the raw depth/camera_info (use for pixels detected on an oriented image).
     """
+    if rotation:
+        point2d = unrotate_pixel(point2d, rotation, image_info.width, image_info.height)
     point_3d = point2d_to_3d(image_info, depth_image, point2d)
     return point3d_to_ros_point_stamped(point_3d, frame_id, stamp, is_optical)


### PR DESCRIPTION
- Add image orienter node to rotate image when zed is rotate, this is very useful for hric, and also 90, 270 degrees are supported.
- Whitout flip:
![WhatsApp Image 2026-04-14 at 1 38 29 AM](https://github.com/user-attachments/assets/45e490d9-8696-4f8c-ac3c-f9bdbba60183)
![WhatsApp Image 2026-04-14 at 1 38 28 AM](https://github.com/user-attachments/assets/d4c53300-2ef9-4bb5-847e-6ff3cc2884c0)
With flip:
![WhatsApp Image 2026-04-14 at 1 38 29 AM (2)](https://github.com/user-attachments/assets/fa5c4cf9-315a-4da0-afcd-ca5e097849b3)
![WhatsApp Image 2026-04-14 at 1 38 29 AM (1)](https://github.com/user-attachments/assets/27cd55d5-2ae7-43df-a4a2-807be953c4fb)
Test point3d with hand detection in deferent rotations
![WhatsApp Image 2026-04-14 at 12 36 08 PM (2)](https://github.com/user-attachments/assets/59e197f1-77e5-4e07-9539-86ca2acd9b27)
![WhatsApp Image 2026-04-14 at 12 36 08 PM (1)](https://github.com/user-attachments/assets/d6ca9f51-046a-4ab8-a1f0-4c0d63b6d192)
![WhatsApp Image 2026-04-14 at 12 36 08 PM](https://github.com/user-attachments/assets/0ab604ee-cb6c-4193-b2f6-a363fbb0cfc9)
![WhatsApp Image 2026-04-14 at 12 36 07 PM](https://github.com/user-attachments/assets/48d3c15f-da44-4f85-9683-e2a49edc894f)
