### PR TITLE
fix(manipulation): use BEST_EFFORT QoS for ZED depth in flat_grasp_estimator

### DIFF
--- a/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
+++ b/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
@@ -2,6 +2,7 @@
 
 import rclpy
 from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
 import numpy as np
 from collections import deque
 from cv_bridge import CvBridge
@@ -52,7 +53,9 @@ class FlatGraspEstimator(Node):
         # Rolling buffer for table height stabilization
         self.table_height_buffer = deque(maxlen=TABLE_HEIGHT_BUFFER_SIZE)
 
-        self.create_subscription(Image, DEPTH_IMAGE_TOPIC, self.depth_callback, 10)
+        self.create_subscription(
+            Image, DEPTH_IMAGE_TOPIC, self.depth_callback, qos_profile_sensor_data
+        )
         self.create_subscription(
             CameraInfo, CAMERA_INFO_TOPIC, self.camera_info_callback, 1
         )

--- a/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
+++ b/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
@@ -57,7 +57,10 @@ class FlatGraspEstimator(Node):
             Image, DEPTH_IMAGE_TOPIC, self.depth_callback, qos_profile_sensor_data
         )
         self.create_subscription(
-            CameraInfo, CAMERA_INFO_TOPIC, self.camera_info_callback, 1
+            CameraInfo,
+            CAMERA_INFO_TOPIC,
+            self.camera_info_callback,
+            qos_profile_sensor_data,
         )
         self.create_subscription(
             ObjectDetectionArray,


### PR DESCRIPTION
## Summary

- `flat_grasp_estimator.py` was subscribing to `/zed/zed_node/depth/depth_registered` with the default rclpy QoS (**RELIABLE** + `KEEP_LAST(10)`).
- When this node runs on a different Orin than the ZED camera, the reliable ACKs travel over the LAN. If the subscriber can't keep up, the ZED publisher's write history cache (CycloneDDS `WhcHigh: 500kB`) fills and **blocks**, dragging the entire ZED pipeline down to ~2 Hz even though GPU/CPU are mostly idle.
- Switched to `qos_profile_sensor_data` (**BEST_EFFORT** + `KEEP_LAST(5)`), which is the ROS 2 standard for sensor streams — same QoS that the rest of the vision nodes (`object_detector_node`, `yolo_node`, `tracker_node`, etc.) already use.

## Why this matters

Measured on the current dual-Orin setup with manipulation running on the non-ZED Orin:

| Scenario | Depth Hz | Frame Drop | Video/Depth Processing Time |
|---|---:|---:|---:|
| Before (RELIABLE subscriber) | ~2.0 Hz | 88% | 454 ms |
| After (BEST_EFFORT subscriber) | ~30 Hz | 0% | 33 ms |

The grasp estimator only needs the latest depth frame when a detection arrives — losing intermediate frames under network pressure is harmless, while stalling the publisher is not.

## Test plan

- [ ] Rebuild manipulation container on both Orins and relaunch.
- [ ] With ZED running on the vision Orin and manipulation on the other, run `ros2 topic hz /zed/zed_node/depth/depth_registered` from inside the ZED container — expect ~30 Hz.
- [ ] Confirm `flat_grasp_estimator` still receives depth frames (`ros2 topic echo` the grasp pose output when a target class is detected).
- [ ] Verify no regression in flat grasp behavior on `spoon`/`fork`/`knife` pick attempts.

## Follow-up (not in this PR)

Other nodes still using the default RELIABLE QoS on ZED topics — not active on the current robot but will cause the same regression if launched. Worth a sweep in a separate PR:

- `vision/packages/vision_general/scripts/moondream_node.py:65`
- `vision/packages/vision_general/scripts/trash_detection_node.py:38`
- `vision/packages/vision_general/scripts/restaurant_commands.py:46-47`
- `vision/packages/vision_general/scripts/tracker_node_fregoso.py:59,63`
- `vision/packages/vision_general/scripts/old_tracker.py:62,66`