### PR TITLE
Vision: ship zero_shot -> /vision/detections relay with the detector

### DIFF
--- a/vision/packages/object_detector_2d/launch/zero_shot_object_detector_node.launch.py
+++ b/vision/packages/object_detector_2d/launch/zero_shot_object_detector_node.launch.py
@@ -2,7 +2,7 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, ExecuteProcess
 from launch.substitutions import LaunchConfiguration
 
 
@@ -13,6 +13,30 @@ def generate_launch_description():
         "parameters_zero_shot.yaml",
     )
     use_sim_time = LaunchConfiguration("use_sim_time", default="false")
+
+    # Bridge /vision/zero_shot_detections -> /vision/detections so pick_server
+    # and keyboard_input see detections under the same topic name they use on
+    # the real robot (where the pretrained detector fills /vision/detections
+    # directly).  topic_tools isn't in the vision image, so inline a tiny
+    # rclpy relay instead of adding a new package dependency.
+    detections_relay = ExecuteProcess(
+        cmd=[
+            "python3",
+            "-c",
+            (
+                "import rclpy\n"
+                "from rclpy.node import Node\n"
+                "from frida_interfaces.msg import ObjectDetectionArray\n"
+                "rclpy.init()\n"
+                "n = Node('zero_shot_to_detections_relay')\n"
+                "pub = n.create_publisher(ObjectDetectionArray, '/vision/detections', 10)\n"
+                "n.create_subscription(ObjectDetectionArray, '/vision/zero_shot_detections', lambda m: pub.publish(m), 10)\n"
+                "n.get_logger().info('zero_shot -> /vision/detections relay up')\n"
+                "rclpy.spin(n)\n"
+            ),
+        ],
+        output="screen",
+    )
 
     return LaunchDescription(
         [
@@ -30,5 +54,6 @@ def generate_launch_description():
                 emulate_tty=False,
                 parameters=[config, {"use_sim_time": use_sim_time}],
             ),
+            detections_relay,
         ]
     )


### PR DESCRIPTION
## Summary
- The sim-only relay bridging \`/vision/zero_shot_detections\` onto \`/vision/detections\` used to live in the manipulation container's sim launch (\`mujoco_spawn/mujoco_sim_init.launch.py\`), which wrongly made the manipulation container a vision publisher.
- The companion manipulation cleanup PR (#923) removed it from there. This PR adds it to \`object_detector_2d\`'s zero_shot launch so the relay ships in the same container as the detector feeding it.
- \`pick_and_place\` keeps listening on \`/vision/detections\` unchanged on both real robot and sim.

## Test plan
- [ ] In the vision container (sim): \`ros2 launch object_detector_2d zero_shot_object_detector_node.launch.py use_sim_time:=true\` — confirm \`/vision/detections\` starts publishing the moment \`/vision/zero_shot_detections\` has output.
- [ ] In the manipulation container: \`ros2 launch pick_and_place pick_and_place.launch.py use_sim_time:=true point_cloud_topic:=/filtered_cloud\` — pick finds the object without any extra relay started manually.
- [ ] Real-robot path unaffected (this launch is only invoked in sim).

## Depends on
- #923 (manipulation-side removal). Merge order: #923 first, then this one.