### PR TITLE
Vision: align ultralytics pin so YOLOE ships in the image

### DIFF
--- a/vision/requirements/moondream.txt
+++ b/vision/requirements/moondream.txt
@@ -2,7 +2,7 @@ numpy==1.26.4
 opencv-python
 grpcio==1.71.0
 protobuf==5.29.1
-ultralytics==8.3.96
+ultralytics==8.4.19
 transformers
 Pillow
 pyvips


### PR DESCRIPTION
## Summary
- \`Dockerfile.cuda\` installs \`moondream.txt\` after \`models.txt\`.  \`models.txt\` pins \`ultralytics==8.4.19\` (required for \`from ultralytics import YOLOE\`, used by the zero-shot detector), but \`moondream.txt\` pinned \`8.3.96\` and silently downgraded the package during image build.
- Result on a freshly built vision image: \`zero_shot_object_detector_node.py\` crashes with \`ImportError: cannot import name 'YOLOE' from 'ultralytics'\`.
- Bump \`moondream.txt\` to \`8.4.19\` so both files pin the same version, no downgrade, YOLOE available out of the box.

## Test plan
- [x] Rebuild the vision image (\`./run.sh vision --build-image\`).
- [x] Inside: \`python3 -c "from ultralytics import YOLOE; print('ok')"\` prints \`ok\`.
- [x] \`ros2 launch object_detector_2d zero_shot_object_detector_node.launch.py use_sim_time:=true\` stays up and publishes \`/vision/zero_shot_detections\` and \`/vision/detections\`.
- [x] moondream still runs (the only other consumer of ultralytics from \`moondream.txt\`).