### PR TITLE
fix(manip): restore real-robot pick after Mujoco PR regression

### DIFF
--- a/manipulation/packages/arm_pkg/arm_pkg/moveit_configs_builder_sim.py
+++ b/manipulation/packages/arm_pkg/arm_pkg/moveit_configs_builder_sim.py
@@ -285,7 +285,6 @@ class MoveItConfigsBuilder(ParameterBuilder):
             'report_type': report_type,
             'baud_checkset': baud_checkset,
             'default_gripper_baud': default_gripper_baud,
-            'mujoco_plugin': "true",
             'dof': dof,
             'robot_type': robot_type,
             'prefix': prefix,
@@ -331,12 +330,14 @@ class MoveItConfigsBuilder(ParameterBuilder):
             'add_vacuum_gripper': add_vacuum_gripper,
             'add_bio_gripper': add_bio_gripper,
             'add_other_geometry': add_other_geometry,
-            'mujoco_plugin': "true",
         }
 
         self.__urdf_package = Path(get_package_share_directory("frida_description"))
-        self.__urdf_file_path = Path("urdf/TMR2025/FRIDA_Real.urdf.xacro")
-        self.__srdf_file_path = Path("srdf/xarm.srdf.xacro")
+        self.__urdf_file_path = Path("urdf/TMR2025/FRIDA.urdf.xacro")
+        if load_zed:
+            self.__srdf_file_path = Path("srdf/xarm.srdf.xacro")
+        else:
+            self.__srdf_file_path = Path("srdf/xarm.srdf.sim.xacro")
 
         self.__robot_description = 'robot_description'
         

--- a/manipulation/packages/pick_and_place/launch/pick_and_place.launch.py
+++ b/manipulation/packages/pick_and_place/launch/pick_and_place.launch.py
@@ -44,8 +44,8 @@ def generate_launch_description():
             ),
             DeclareLaunchArgument(
                 "pick_min_height",
-                default_value="0.1",
-                description="Minimum height (m) a grasp pose must clear above the detected support plane. Real robot 0.1; sim lowers this because the plane segmenter tends to pick a wrong plane off the house mesh.",
+                default_value="0.04",
+                description="Minimum height (m) a grasp pose must clear above the detected support plane. Matches PICK_MIN_HEIGHT used before the parameter was exposed; sim can lower it because the plane segmenter sometimes picks a wrong plane off the house mesh.",
             ),
             Node(
                 package="pick_and_place",

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -40,7 +40,7 @@ import numpy as np
 from tf_transformations import quaternion_from_euler
 import tf2_ros
 from transforms3d.quaternions import quat2mat
-from frida_motion_planning.utils.tf_utils import transform_point
+from frida_motion_planning.utils.tf_utils import transform_point, transform_pose
 from frida_motion_planning.utils.service_utils import (
     close_gripper,
     open_gripper,
@@ -799,7 +799,24 @@ class PickMotionServer(Node):
                 return True
             return False
 
-        pick_height = pose.pose.position.z
+        # Grasp poses arrive in base_link (gpd_service target_frame) but the
+        # plane primitive comes back from MoveIt in the planning frame (world,
+        # which is 0.3 m above base_link on the real robot — the physical
+        # pedestal offset baked into FRIDA_Real.urdf.xacro). Comparing z values
+        # without transforming silently rejects every valid grasp by that 0.3 m.
+        plane_frame = self.plane.pose.header.frame_id
+        pose_in_plane_frame = pose
+        if plane_frame and plane_frame != pose.header.frame_id:
+            ok, transformed = transform_pose(pose, plane_frame, self.tf_buffer)
+            if not ok:
+                self.get_logger().error(
+                    f"check_feasibility: failed to transform pose from "
+                    f"{pose.header.frame_id} to {plane_frame}; assuming infeasible"
+                )
+                return False
+            pose_in_plane_frame = transformed
+
+        pick_height = pose_in_plane_frame.pose.position.z
         plane_height = self.plane.pose.pose.position.z + self.plane.dimensions.z / 2
 
         # Cutlery keeps its own constant (flatter objects need tighter tolerance);


### PR DESCRIPTION
The Mujoco PR (#739) forced FRIDA_Real.urdf.xacro + mujoco_plugin=true for the real robot in moveit_configs_builder_sim.py. That URDF unconditionally adds a 'world' link sitting 0.3 m below base_link via the world_to_base joint, which made MoveIt's planning frame 'world' instead of 'base_link'.

Consequences on the real robot:
- The plane collision object added in base_link was stored by MoveIt in 'world', 0.3 m above its real z. pick_server.check_feasibility compared grasp poses (still in base_link) against the offset plane z, so every valid grasp got rejected as 'below acceptable height'.
- pick_min_height launch default jumped from PICK_MIN_HEIGHT (0.04) to 0.1, tightening the same already-broken check.

Restore the Apr 16 working state for the real robot:
- moveit_configs_builder_sim.py: revert URDF/SRDF selection and drop the forced mujoco_plugin=true. Real robot is back on FRIDA.urdf.xacro and the conditional .sim SRDF, which keeps planning_frame = base_link. NOTE: this reverts MuJoCo sim support; sim needs a dedicated config path before it can be re-enabled.
- pick_and_place.launch.py: pick_min_height default back to 0.04.
- pick_server.check_feasibility: transform the candidate pose into the plane's frame via tf2 before comparing z. No-op when frames already match (current real-robot case), but defensive against a future split between planning frame and gpd target_frame.

Verified: apple pick on the real xArm6 now plans + executes after this change.