### PR TITLE
fix(sim): make FRIDA visible in MuJoCo and stabilize gripper fingers

### DIFF
--- a/manipulation/packages/arm_pkg/arm_pkg/moveit_configs_builder_sim.py
+++ b/manipulation/packages/arm_pkg/arm_pkg/moveit_configs_builder_sim.py
@@ -321,6 +321,7 @@ class MoveItConfigsBuilder(ParameterBuilder):
             'geometry_mesh_tcp_rpy': geometry_mesh_tcp_rpy,
             'load_zed': load_zed,
             'simulation': "True",
+            'mujoco_plugin': 'true',
         }
         self.__srdf_xacro_args = {
             'prefix': prefix,

--- a/manipulation/packages/mujoco_spawn/launch/mujoco_sim_init.launch.py
+++ b/manipulation/packages/mujoco_spawn/launch/mujoco_sim_init.launch.py
@@ -31,6 +31,7 @@ def generate_nodes_for_spawn(context: LaunchContext):
     effort_control = LaunchConfiguration("effort_control", default=False)
     velocity_control = LaunchConfiguration("velocity_control", default=False)
     add_gripper = LaunchConfiguration("add_gripper", default=False)
+    load_zed = LaunchConfiguration("load_zed", default=True)
     add_vacuum_gripper = LaunchConfiguration("add_vacuum_gripper", default=False)
     add_bio_gripper = LaunchConfiguration("add_bio_gripper", default=False)
     dof = LaunchConfiguration("dof", default=6)
@@ -151,6 +152,7 @@ def generate_nodes_for_spawn(context: LaunchContext):
         ros2_control_plugin=ros2_control_plugin,
         ros2_control_params="/tmp/final_frida.yaml",
         add_gripper=add_gripper,
+        load_zed=load_zed,
         add_vacuum_gripper=add_vacuum_gripper,
         add_bio_gripper=add_bio_gripper,
         add_realsense_d435i=add_realsense_d435i,
@@ -421,6 +423,7 @@ def generate_launch_description():
         [
             DeclareLaunchArgument("launch_moveit", default_value="false"),
             DeclareLaunchArgument("launch_perception", default_value="false"),
+            DeclareLaunchArgument("load_zed", default_value="true"),
             OpaqueFunction(function=generate_nodes_for_spawn),
         ]
     )

--- a/robot_description/frida_description/urdf/Gripper/Custom/gripper.xacro
+++ b/robot_description/frida_description/urdf/Gripper/Custom/gripper.xacro
@@ -122,11 +122,11 @@
            contact compute cost; condim=4 is the sweet spot: kills the
            rotation-around-normal failure mode while staying realtime. -->
       <reference name="right_finger">
-          <joint range="0 0.056" limited="true" />
+          <joint range="0 0.056" limited="true" damping="5.0" armature="0.01"/>
           <geom name="right_finger_collision_0" friction="5.0 2.0 0.2" solref="-50000 -500" solimp="0.98 0.999 0.0001" condim="4"/>
       </reference>
       <reference name="left_finger">
-          <joint range="0 0.056" limited="true" />
+          <joint range="0 0.056" limited="true" damping="5.0" armature="0.01"/>
           <geom name="left_finger_collision_0" friction="5.0 2.0 0.2" solref="-50000 -500" solimp="0.98 0.999 0.0001" condim="4"/>
       </reference>
       <equality>

--- a/robot_description/frida_description/urdf/TMR2025/FRIDA.urdf.xacro
+++ b/robot_description/frida_description/urdf/TMR2025/FRIDA.urdf.xacro
@@ -99,11 +99,8 @@
     <xacro:if value="$(arg load_zed)">
       <xacro:include filename="$(find frida_description)/urdf/Gripper/Custom/gripper.xacro" />
       <xacro:load_gripper attach_to="link_eef" xyz="0 0 0.046" rpy="0 0 3.926" fixed_joints="false" mujoco_plugin="$(arg mujoco_plugin)" />
-      <!-- ZED MACRO -->
-      <xacro:include filename="$(find frida_description)/urdf/zed/zed_macro.urdf.xacro" />
-      <xacro:zed_camera name="zed" model="zed2" custom_baseline="0" enable_gnss="false" simulation="true" attach_to="zed" xyz="0 0 0" rpy="0 0 0">
-          <origin xyz="0 0 0" rpy="0 0 0"/>
-      </xacro:zed_camera>
+      <xacro:include filename="$(find frida_description)/urdf/zed/zed.xacro" />
+      <xacro:load_zed attach_to="zed" xyz="0 0 0" rpy="0 0 0" mujoco_plugin="$(arg mujoco_plugin)" />
     </xacro:if>
 
     <!-- <xacro:if value="$(arg load_zed)"> -->


### PR DESCRIPTION
## Summary

After `Simulation fixes (#966)` merged, launching the sim container produced an empty MJCF for FRIDA: MuJoCo opened with only the house, the ZED camera window never appeared, and ros2_control could not find `joint1..joint6` or the gripper interfaces. This PR is the follow-up that actually makes the sim work end-to-end.

### Root cause chain

1. `urdf2mjcf.py` (from the mujoco_ros2_control submodule) starts its body-tree recursion from a hardcoded link named `world`. If the URDF doesn't have one, the converter silently emits `<worldbody />` and the model is empty.
2. `FRIDA.urdf.xacro` has a `<xacro:if mujoco_plugin>` block that emits exactly that `world` link plus the `world_to_base` floating joint, the global `<mujoco><compiler/></mujoco>` config, and per-link `gravcomp` references.
3. `moveit_configs_builder_sim.py` builds the URDF via `load_xacro(...)` but its `__urdf_xacro_args` dict was missing `mujoco_plugin`, so the xacro defaulted to `false` and the entire mujoco-mode block was stripped.
4. The custom gripper (`rightfinger`/`leftfinger`) and the ZED camera body sit behind `<xacro:if load_zed>`, which the launch wasn't declaring either.
5. With `load_zed` re-enabled the xacro pulled in the *official* `zed_camera` macro from `zed_macro.urdf.xacro`, which requires `zed2.stl` from `zed_msgs` — an apt package whose meshes don't ship, and which also doesn't emit the `<mujoco><camera name=\"zed_mujoco_camera_link\"/>` reference the launch's topic remappings expect.
6. Finally, `urdf2mjcf.py` copies `<dynamics damping=.../>` for revolute joints but not for prismatic ones, so the fingers were undamped against a `kp=1000` position actuator and oscillated.

### Changes

- **`manipulation/packages/arm_pkg/arm_pkg/moveit_configs_builder_sim.py`** — pass `'mujoco_plugin': 'true'` to the xacro mappings.
- **`manipulation/packages/mujoco_spawn/launch/mujoco_sim_init.launch.py`** — declare `load_zed` and default it to `true`; propagate to `MoveItConfigsBuilder`.
- **`robot_description/frida_description/urdf/TMR2025/FRIDA.urdf.xacro`** — swap the official `zed_camera` macro for the custom `load_zed` from `zed.xacro` (same pattern `FRIDA_Real.urdf.xacro` already uses). Removes the implicit `zed_msgs` dependency and emits the MuJoCo camera reference the launch expects.
- **`robot_description/frida_description/urdf/Gripper/Custom/gripper.xacro`** — add `damping=\"5.0\" armature=\"0.01\"` to the `<reference>` joint blocks for `right_finger` and `left_finger`, so `xacro2mjcf` merges them onto the slide joints in the MJCF.

### Result

- `FRIDA.xml` grew from 4 lines (empty `<worldbody/>`) to 147 with the full kinematic chain (`base_link → xarm_base → link_base → link1..link6`).
- `Sim environment setup complete` in the launch log; controllers `joint_state_broadcaster`, `xarm6_traj_controller`, `xarm_gripper_traj_controller` all load.
- `/zed/zed_node/rgb/image_rect_color` publishing at ~5–8 Hz, `/clock` active.
- Verified the sim runs **without** `ros-humble-zed-msgs` installed — no longer required.
- Fingers no longer oscillate.

## Test plan

- [x] `./run.sh simulation --sim` brings MuJoCo up with FRIDA visible on/in the house.
- [x] `ros2 topic hz /zed/zed_node/rgb/image_rect_color` reports a stable rate.
- [x] `ros2 topic list` shows all `/zed/zed_node/...` and controller topics.
- [x] Gripper fingers stay stable when the model is idle.
- [ ] Brain container (manipulation) connects and can plan via MoveIt with `launch_moveit:=true`.
- [ ] Pick task end-to-end (follow-up).