### PR TITLE
Fix CycloneDDS config blocking real-hardware DDS in manipulation container

### DIFF
--- a/docker/manipulation/.bash_aliases
+++ b/docker/manipulation/.bash_aliases
@@ -5,4 +5,15 @@ alias build='cd /workspace && source frida_interfaces_cache/install/local_setup.
 # loopback is unreliable). MaxAutoParticipantIndex=120 in the XML is
 # needed because the full pick stack spawns 20+ ROS nodes and the
 # ROS_LOCALHOST_ONLY=1 default of 9 is too small.
-export CYCLONEDDS_URI=file:///workspace/src/docker/manipulation/cyclonedds_sim.xml
+#
+# Conditional default: the sim XML stays the default for MuJoCo runs,
+# but an external override (e.g. CYCLONEDDS_URI=file:///etc/cyclonedds.xml
+# exported before container start on real hardware) takes precedence so
+# inter-container topic data flow with the ZED/perception stack isn't
+# blocked by the sim's localhost-only multicast config.
+export CYCLONEDDS_URI="${CYCLONEDDS_URI:-file:///workspace/src/docker/manipulation/cyclonedds_sim.xml}"
+
+# VAMP Python bindings live in the submodule's src/ dir (not pip-installed).
+# setup_vamp.sh exports this at entrypoint, but interactive shells need it
+# too — `ros2 run vamp_moveit_plugin vamp_server.py` relies on it.
+export PYTHONPATH="/workspace/src/manipulation/packages/vamp/src:$PYTHONPATH"


### PR DESCRIPTION
## Summary
  - `.bash_aliases` in `docker/manipulation/` unconditionally forced the sim-only CycloneDDS config, which broke topic data flow from
  other containers (ZED, perception) on real hardware. Change to conditional `${CYCLONEDDS_URI:-...}` so the sim XML stays the default
  but external overrides win.
  - Also export `PYTHONPATH` to include the VAMP submodule `src/` directory so `ros2 launch vamp_moveit_plugin vamp_server.launch.py` 
  finds the `vamp` Python module in every interactive shell (not just in the entrypoint where `setup_vamp.sh` runs).

  ## Why
  **CycloneDDS bug**: Discovered on Orin (192.168.31.10) during Tier 4 VAMP real-robot testing: `ros2 topic list` showed 
  `/zed/zed_node/point_cloud/cloud_registered` but `ros2 topic echo --once` hung indefinitely. The ZED container uses 
  `/etc/cyclonedds.xml` (Iceoryx SHM-aware), the manipulation container was forced to `cyclonedds_sim.xml` (localhost multicast only). 
  Topic discovery worked via shared `/dev/shm/iceoryx_mgmt` but the actual data path didn't bridge.

  **PYTHONPATH bug**: `setup_vamp.sh` exports this at container entrypoint, but `docker exec`-spawned interactive shells inherited no 
  such export, so `ros2 launch vamp_moveit_plugin vamp_server.launch.py` crashed with `ModuleNotFoundError: No module named 'vamp'`. 
  Adding the export to `.bash_aliases` (which `~/.bashrc` auto-sources) makes every interactive shell find the module without manual 
  sourcing.
  
  ## Test plan
  - [x] MuJoCo workflow unchanged: container without `CYCLONEDDS_URI` override picks up the sim XML
  - [x] Real-hardware override works: `CYCLONEDDS_URI=file:///etc/cyclonedds.xml ./run.sh manipulation` respects the value inside the 
  container
  - [x] `vamp_server.launch.py` starts without manual source after fresh `./run.sh manipulation --build`
  - [x] Tier 4 R5 (octomap from ZED): real-data planning succeeds end-to-end on Orin
  - [x] No regression on existing fake-mode or sim workflows
  
  ## Scope
  One file, two related fixes both touching the manipulation container's interactive shell setup. Does not change behavior for MuJoCo or fake-mode setups.