### PR TITLE
docs: update README so current and new HOME members can add themselves as contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ For detailed configuration options, see the [CycloneDDS setup docs](docs/cyclone
 | Daniela Herrera | [@DanHeGa](https://github.com/DanHeGa) | Vision |
 | Gilberto Malagamba | [@GilMM27](https://github.com/GilMM27) | HRI, Integration |
 | Jose Dominguez | [@JLDominguezM](https://github.com/JLDominguezM) | Manipulation, Integration |
+| Hector Tovar | [@htovarm7](https://github.com/htovarm7) | Manipulation, Vision |
 
 ## Past Contributors
 


### PR DESCRIPTION
## Description
The goal of this PR is to serve as a reference so that current and new @home team members can easily add themselves to the contributors list