### PR TITLE
Remove stale SRDF entries for non-existent zed_camera_center link

### DIFF
--- a/robot_description/frida_description/srdf/_xarm6_macro.srdf.xacro
+++ b/robot_description/frida_description/srdf/_xarm6_macro.srdf.xacro
@@ -303,7 +303,6 @@
     <disable_collisions link1="gripper" link2="link5" reason="Never"/>
     <disable_collisions link1="gripper" link2="link6" reason="Adjacent"/>
     <disable_collisions link1="gripper" link2="right_finger" reason="Adjacent"/>
-    <disable_collisions link1="gripper" link2="zed_camera_center" reason="Adjacent"/>
     <disable_collisions link1="intel_realsense" link2="laser" reason="Never"/>
     <disable_collisions link1="intel_realsense" link2="link1" reason="Never"/>
     <disable_collisions link1="intel_realsense" link2="link2" reason="Never"/>
@@ -316,7 +315,6 @@
     <disable_collisions link1="left_finger" link2="link5" reason="Never"/>
     <disable_collisions link1="left_finger" link2="link6" reason="Never"/>
     <disable_collisions link1="left_finger" link2="right_finger" reason="Default"/>
-    <disable_collisions link1="left_finger" link2="zed_camera_center" reason="Never"/>
     <disable_collisions link1="link1" link2="link2" reason="Adjacent"/>
     <disable_collisions link1="link1" link2="link3" reason="Never"/>
     <disable_collisions link1="link1" link2="link_base" reason="Adjacent"/>
@@ -325,14 +323,10 @@
     <disable_collisions link1="link3" link2="link4" reason="Adjacent"/>
     <disable_collisions link1="link3" link2="link5" reason="Never"/>
     <disable_collisions link1="link3" link2="link6" reason="Never"/>
-    <disable_collisions link1="link3" link2="zed_camera_center" reason="Never"/>
     <disable_collisions link1="link4" link2="link5" reason="Adjacent"/>
     <disable_collisions link1="link4" link2="link6" reason="Never"/>
     <disable_collisions link1="link5" link2="link6" reason="Adjacent"/>
     <disable_collisions link1="link5" link2="right_finger" reason="Never"/>
-    <disable_collisions link1="link5" link2="zed_camera_center" reason="Never"/>
     <disable_collisions link1="link6" link2="right_finger" reason="Never"/>
-    <disable_collisions link1="link6" link2="zed_camera_center" reason="Never"/>
-    <disable_collisions link1="right_finger" link2="zed_camera_center" reason="Never"/>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
## Summary

- The URDF defines the ZED camera link as `zed_camera_link` (in `robot_description/frida_description/urdf/zed/zed.xacro:15`), but the SRDF contained six `disable_collisions` entries pointing to a non-existent link named `zed_camera_center`.
- RViz logged `Link 'zed_camera_center' is not known to URDF` repeatedly during motion-planning panel use.
- All six entries were redundant — each had an equivalent `disable_collisions` with the correct `zed_camera_link` already present at lines 99-105 covering the same link pairs.

## Change

Six lines removed from `robot_description/frida_description/srdf/_xarm6_macro.srdf.xacro`:

| Removed (wrong link name) | Already-present equivalent |
|---|---|
| `gripper ↔ zed_camera_center` | `zed_camera_link ↔ gripper` (line 100) |
| `left_finger ↔ zed_camera_center` | `zed_camera_link ↔ left_finger` (line 101) |
| `link3 ↔ zed_camera_center` | `zed_camera_link ↔ link3` (line 102) |
| `link5 ↔ zed_camera_center` | `zed_camera_link ↔ link5` (line 103) |
| `link6 ↔ zed_camera_center` | `zed_camera_link ↔ link6` (line 104) |
| `right_finger ↔ zed_camera_center` | `zed_camera_link ↔ right_finger` (line 105) |

Zero functional change to collision checking — the wrong-name entries had no effect because the link they referenced does not exist.

## Test plan

- [x] Launch `frida_fake_moveit_config.launch.py` and open the MoveIt Motion Planning panel in RViz; confirm the `Link 'zed_camera_center' is not known to URDF` warning no longer appears.
- [x] Plan a joint goal and a Cartesian goal that previously worked; confirm planning still succeeds and collision behaviour around the gripper/fingers/links 3-6 vs. the ZED camera link is unchanged.