### PR TITLE
Auto-compile VAMP Python bindings on manipulation container startup

### DIFF
--- a/docker/manipulation/run.sh
+++ b/docker/manipulation/run.sh
@@ -24,11 +24,14 @@ GPD_EXPORT="export GPD_INSTALL_DIR=/workspace/install/gpd"
 SOURCE="if [ -f install/setup.bash ]; then source install/setup.bash; fi"
 COLCON="colcon build --symlink-install --packages-up-to manipulation_general xarm6_ikfast_plugin xarm_utils vamp_moveit_plugin --packages-ignore realsense_gazebo_plugin xarm_gazebo frida_interfaces"
 CYCLONE_SOURCE="source /usr/local/bin/cyclonedds_setup.sh"
+# Build VAMP's _core_ext.*.so if missing (~1s no-op when already built); the normal colcon build above doesn't produce it.
+# Non-fatal: keep going on failure since the plugin's OMPL fallback works without VAMP.
+VAMP_SETUP="(bash /workspace/src/docker/manipulation/setup_vamp.sh || echo '[WARN] VAMP setup failed — vamp planning unavailable, OMPL fallback still works')"
 
 if [ "$BUILD" == "true" ]; then
-    SETUP="$GPD_SETUP && $GPD_EXPORT && $SOURCE_ROS && $SOURCE_INTERFACES &&  $CYCLONE_SOURCE && $COLCON && $SOURCE"
+    SETUP="$GPD_SETUP && $GPD_EXPORT && $SOURCE_ROS && $SOURCE_INTERFACES &&  $CYCLONE_SOURCE && $COLCON && $SOURCE && $VAMP_SETUP"
 else
-    SETUP="$GPD_SETUP && $GPD_EXPORT && $SOURCE_ROS && $SOURCE_INTERFACES && $SOURCE &&  $CYCLONE_SOURCE "
+    SETUP="$GPD_SETUP && $GPD_EXPORT && $SOURCE_ROS && $SOURCE_INTERFACES && $SOURCE &&  $CYCLONE_SOURCE && $VAMP_SETUP"
 fi
 
 case $TASK in

--- a/manipulation/packages/vamp_moveit_plugin/ReadMe.md
+++ b/manipulation/packages/vamp_moveit_plugin/ReadMe.md
@@ -6,6 +6,22 @@ VAMP (Vectorized And Motion Planning) is an ultra-fast motion planner for the FR
 
 ---
 
+## Setup / first run
+
+VAMP has two pieces that must be in place before `vamp_server.py` (or the `vamp` planner pipeline) works:
+
+1. **The `vamp` submodule source** — checked out under `manipulation/packages/vamp/`. Like every other submodule in this repo, this is a one-time step after cloning or after a pull that adds/changes the submodule (switching branches does **not** update submodule working trees):
+   ```bash
+   git submodule update --init --recursive manipulation/packages/vamp
+   ```
+   Symptom if missing: `ModuleNotFoundError: No module named 'vamp'` (the whole package is absent).
+
+2. **The compiled Python bindings** (`_core_ext.*.so`) — these are a non-standard build artifact that the normal `colcon build` does **not** produce. `./run.sh manipulation` now runs `docker/manipulation/setup_vamp.sh` automatically on container startup: it short-circuits (~1 s) when the `.so` is already built and compiles it (~1–2 min) only when missing. No manual step needed. Symptom if it were missing: `ModuleNotFoundError: No module named 'vamp._core._core_ext'` (package present, binding absent).
+
+If the auto-compile ever fails, the launch/shell still proceeds (the planner's OMPL fallback works without VAMP); you can rebuild manually with `bash /workspace/src/docker/manipulation/setup_vamp.sh` inside the container.
+
+---
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary

- The `vamp` Python bindings (`_core_ext.*.so`) are a non-standard build artifact — the normal `colcon build` does **not** produce them. After a clean build, a fresh clone, or a platform change (x86 ↔ aarch64) the `.so` goes missing and `vamp_server.py` / the `vamp` planner pipeline fail with `ModuleNotFoundError: No module named 'vamp._core._core_ext'`.
- `docker/manipulation/run.sh` now runs `setup_vamp.sh` as part of the container SETUP chain (both with and without `--build`). It short-circuits in ~1s when the `.so` already exists and compiles it (~1–2 min) only when missing.
- The call is wrapped (`... || echo WARN`) so a build failure is **non-fatal**: the shell/launch still proceeds because the planner's OMPL fallback works without VAMP, rather than locking the user out of the container.

## Why submodule checkout is *not* automated here

The `vamp` submodule source is checked out the same way as every other submodule in the repo — a one-time `git submodule update --init --recursive` after clone or after a pull that adds it. Special-casing only `vamp` would be inconsistent with `gpd`, `pymoveit2`, `xarm_ros2`, `mujoco_ros2_control`. The genuinely VAMP-specific need is the **`.so` compile** (a build step no other submodule has), which is what this PR automates. The manual submodule step and the two distinct `ModuleNotFoundError` symptoms are documented in the plugin ReadMe.

## Test plan

Validated on x86 laptop with the running `home2-manipulation` container, exercising the exact command the SETUP chain generates:

- [x] **`.so` present** → `setup_vamp.sh` short-circuits in **0.34s** ("VAMP already compiled with frida_real") — negligible startup overhead.
- [x] **`.so` missing** → detects ("No compiled .so found"), compiles in **46.5s**, copies it, verifies `import vamp` → "VAMP ready — frida_real with 68 spheres".
- [x] **Failure path** → with a non-existent setup script, the `|| echo` fires and the `&&` chain still reaches the RUN step (no lock-out).
- [x] `import vamp` works after rebuild: `OK spheres: 68`.

## Files

| File | Change |
|---|---|
| `docker/manipulation/run.sh` | Add `VAMP_SETUP` to the SETUP chain (both build/non-build branches), wrapped for non-fatal failure |
| `manipulation/packages/vamp_moveit_plugin/ReadMe.md` | New "Setup / first run" section: submodule one-time step + auto-compile behavior + the two ModuleNotFoundError symptoms |