### PR TITLE
Start vamp_server with frida moveit config launches (toggleable)

### DIFF
--- a/manipulation/packages/arm_pkg/launch/frida_fake_moveit_config.launch.py
+++ b/manipulation/packages/arm_pkg/launch/frida_fake_moveit_config.launch.py
@@ -278,11 +278,8 @@ def launch_setup(context, *args, **kwargs):
             )
         )
 
-    # VAMP planning server. The "vamp" pipeline is the default planner (set
-    # above), so its backend must be running or every plan waits ~3s for the
-    # service, times out, and falls back to OMPL. Start it here by default;
-    # disable with start_vamp_server:=false to exercise the OMPL fallback or
-    # run the server separately.
+    # Start the VAMP backend ("vamp" is the default planner; without it every plan
+    # waits ~3s then falls back to OMPL). Disable with start_vamp_server:=false.
     vamp_server_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(

--- a/manipulation/packages/arm_pkg/launch/frida_fake_moveit_config.launch.py
+++ b/manipulation/packages/arm_pkg/launch/frida_fake_moveit_config.launch.py
@@ -16,6 +16,7 @@ from launch.actions import (
 )
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.conditions import IfCondition
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node
 from arm_pkg.moveit_configs_builder import MoveItConfigsBuilder
@@ -277,7 +278,28 @@ def launch_setup(context, *args, **kwargs):
             )
         )
 
+    # VAMP planning server. The "vamp" pipeline is the default planner (set
+    # above), so its backend must be running or every plan waits ~3s for the
+    # service, times out, and falls back to OMPL. Start it here by default;
+    # disable with start_vamp_server:=false to exercise the OMPL fallback or
+    # run the server separately.
+    vamp_server_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("vamp_moveit_plugin"),
+                    "launch",
+                    "vamp_server.launch.py",
+                ]
+            )
+        ),
+        condition=IfCondition(
+            LaunchConfiguration("start_vamp_server", default="true")
+        ),
+    )
+
     return [
+        vamp_server_launch,
         robot_description_launch,
         robot_moveit_common_launch,
         joint_state_broadcaster,

--- a/manipulation/packages/arm_pkg/launch/frida_fake_moveit_config.launch.py
+++ b/manipulation/packages/arm_pkg/launch/frida_fake_moveit_config.launch.py
@@ -293,9 +293,7 @@ def launch_setup(context, *args, **kwargs):
                 ]
             )
         ),
-        condition=IfCondition(
-            LaunchConfiguration("start_vamp_server", default="true")
-        ),
+        condition=IfCondition(LaunchConfiguration("start_vamp_server", default="true")),
     )
 
     return [

--- a/manipulation/packages/arm_pkg/launch/frida_moveit_config.launch.py
+++ b/manipulation/packages/arm_pkg/launch/frida_moveit_config.launch.py
@@ -18,6 +18,7 @@ from launch.actions import (
 )
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.conditions import IfCondition
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node
 from arm_pkg.moveit_configs_builder import MoveItConfigsBuilder
@@ -255,11 +256,32 @@ def launch_setup(context, *args, **kwargs):
         ],
     )
 
+    # VAMP planning server. The "vamp" pipeline is the default planner, so its
+    # backend must be running or every plan waits ~3s for the service, times
+    # out, and falls back to OMPL. Start it here by default; disable with
+    # start_vamp_server:=false to exercise the OMPL fallback or run the server
+    # separately.
+    vamp_server_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("vamp_moveit_plugin"),
+                    "launch",
+                    "vamp_server.launch.py",
+                ]
+            )
+        ),
+        condition=IfCondition(
+            LaunchConfiguration("start_vamp_server", default="true")
+        ),
+    )
+
     return [
         SetEnvironmentVariable(name="ROS_LOG_LEVEL", value=log_level),
         SetEnvironmentVariable(
             name="RCUTILS_LOGGING_SEVERITY_THRESHOLD", value=log_level
         ),
+        vamp_server_launch,
         robot_description_launch,
         robot_moveit_common_launch,
         joint_state_publisher_node,

--- a/manipulation/packages/arm_pkg/launch/frida_moveit_config.launch.py
+++ b/manipulation/packages/arm_pkg/launch/frida_moveit_config.launch.py
@@ -271,9 +271,7 @@ def launch_setup(context, *args, **kwargs):
                 ]
             )
         ),
-        condition=IfCondition(
-            LaunchConfiguration("start_vamp_server", default="true")
-        ),
+        condition=IfCondition(LaunchConfiguration("start_vamp_server", default="true")),
     )
 
     return [

--- a/manipulation/packages/arm_pkg/launch/frida_moveit_config.launch.py
+++ b/manipulation/packages/arm_pkg/launch/frida_moveit_config.launch.py
@@ -256,11 +256,8 @@ def launch_setup(context, *args, **kwargs):
         ],
     )
 
-    # VAMP planning server. The "vamp" pipeline is the default planner, so its
-    # backend must be running or every plan waits ~3s for the service, times
-    # out, and falls back to OMPL. Start it here by default; disable with
-    # start_vamp_server:=false to exercise the OMPL fallback or run the server
-    # separately.
+    # Start the VAMP backend ("vamp" is the default planner; without it every plan
+    # waits ~3s then falls back to OMPL). Disable with start_vamp_server:=false.
     vamp_server_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(

--- a/manipulation/packages/vamp_moveit_plugin/ReadMe.md
+++ b/manipulation/packages/vamp_moveit_plugin/ReadMe.md
@@ -97,17 +97,22 @@ On first run, `setup_vamp.sh` automatically:
 
 ### Step 3 — Launch and plan
 
-In terminal 1 (inside container):
+Inside the container:
 ```bash
 source /workspace/install/setup.bash
 ros2 launch arm_pkg frida_fake_moveit_config.launch.py
 ```
 
-In terminal 2 (inside container):
+This **also starts `vamp_server.py` automatically** (the "vamp" pipeline is the default planner, so its backend must be running). To disable it — e.g. to exercise the OMPL fallback, or to run the server separately/remotely — pass:
 ```bash
-export PYTHONPATH="/workspace/src/manipulation/packages/vamp/src:$PYTHONPATH"
-ros2 run vamp_moveit_plugin vamp_server.py
+ros2 launch arm_pkg frida_fake_moveit_config.launch.py start_vamp_server:=false
 ```
+and then launch the server yourself in another terminal:
+```bash
+ros2 run vamp_moveit_plugin vamp_server.py   # PYTHONPATH is set by .bash_aliases
+```
+
+The same `start_vamp_server` argument exists on the real `frida_moveit_config.launch.py`.
 
 Then open RViz, set the planning group to `xarm6`, set a goal state, and click **Plan**.
 

--- a/manipulation/packages/vamp_moveit_plugin/launch/vamp_server.launch.py
+++ b/manipulation/packages/vamp_moveit_plugin/launch/vamp_server.launch.py
@@ -86,9 +86,7 @@ def launch_setup(context, *args, **kwargs):
             executable="vamp_server.py",
             name="vamp_server",
             output="screen",
-            parameters=[
-                {name: LaunchConfiguration(name) for name in _SERVER_PARAMS}
-            ],
+            parameters=[{name: LaunchConfiguration(name) for name in _SERVER_PARAMS}],
         )
     ]
 
@@ -109,7 +107,9 @@ def generate_launch_description():
     }
 
     declared_args = [
-        DeclareLaunchArgument(name, default_value=default, description=arg_descriptions[name])
+        DeclareLaunchArgument(
+            name, default_value=default, description=arg_descriptions[name]
+        )
         for name, default in _SERVER_PARAMS.items()
     ]
     declared_args.append(

--- a/manipulation/packages/vamp_moveit_plugin/launch/vamp_server.launch.py
+++ b/manipulation/packages/vamp_moveit_plugin/launch/vamp_server.launch.py
@@ -13,102 +13,111 @@ Parameters are tunable at launch:
     max_iterations:=100000 \
     range:=0.03 \
     security_margin:=0.03
+
+Singleton guard:
+  The frida moveit configs include this launch file (start_vamp_server:=true),
+  so running it again by hand would create a second node named "vamp_server"
+  — a name collision that makes the VAMP service ambiguous. To prevent that,
+  this launch checks the ROS graph at startup and skips launching if a
+  "vamp_server" node is already running. Override with force:=true if you
+  really want a second instance.
 """
 
+import subprocess
+
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
-def generate_launch_description():
-    return LaunchDescription(
-        [
-            # ── Launch arguments ────────────────────────────────────
-            DeclareLaunchArgument(
-                "max_iterations",
-                default_value="50000",
-                description="Max RRT iterations per attempt",
-            ),
-            DeclareLaunchArgument(
-                "range",
-                default_value="0.05",
-                description="RRT extension range in C-space",
-            ),
-            DeclareLaunchArgument(
-                "security_margin",
-                default_value="0.02",
-                description="Extra collision margin (meters)",
-            ),
-            DeclareLaunchArgument(
-                "max_retries",
-                default_value="3",
-                description="Number of planning retries with increasing params",
-            ),
-            DeclareLaunchArgument(
-                "finger_left_default",
-                default_value="0.8",
-                description="Default left finger joint value",
-            ),
-            DeclareLaunchArgument(
-                "finger_right_default",
-                default_value="0.8",
-                description="Default right finger joint value",
-            ),
-            DeclareLaunchArgument(
-                "validation_step_size",
-                default_value="0.05",
-                description="Interpolation step for path validation (radians)",
-            ),
-            DeclareLaunchArgument(
-                "smoothing_window",
-                default_value="5",
-                description="Moving average window for path smoothing",
-            ),
-            DeclareLaunchArgument(
-                "smoothing_passes",
-                default_value="3",
-                description="Number of smoothing passes",
-            ),
-            DeclareLaunchArgument(
-                "min_r_point",
-                default_value="0.09",
-                description="Minimum collision radius per voxel (compensates sphere model)",
-            ),
-            DeclareLaunchArgument(
-                "self_filter_distance",
-                default_value="0.12",
-                description="Distance to filter robot body from pointcloud (meters)",
-            ),
-            # ── VAMP Server Node ────────────────────────────────────
-            Node(
-                package="vamp_moveit_plugin",
-                executable="vamp_server.py",
-                name="vamp_server",
-                output="screen",
-                parameters=[
-                    {
-                        "max_iterations": LaunchConfiguration("max_iterations"),
-                        "range": LaunchConfiguration("range"),
-                        "security_margin": LaunchConfiguration("security_margin"),
-                        "max_retries": LaunchConfiguration("max_retries"),
-                        "finger_left_default": LaunchConfiguration(
-                            "finger_left_default"
-                        ),
-                        "finger_right_default": LaunchConfiguration(
-                            "finger_right_default"
-                        ),
-                        "validation_step_size": LaunchConfiguration(
-                            "validation_step_size"
-                        ),
-                        "smoothing_window": LaunchConfiguration("smoothing_window"),
-                        "smoothing_passes": LaunchConfiguration("smoothing_passes"),
-                        "min_r_point": LaunchConfiguration("min_r_point"),
-                        "self_filter_distance": LaunchConfiguration(
-                            "self_filter_distance"
-                        ),
-                    }
-                ],
-            ),
-        ]
+# (param name -> default value) for every tunable the server accepts.
+_SERVER_PARAMS = {
+    "max_iterations": "50000",
+    "range": "0.05",
+    "security_margin": "0.02",
+    "max_retries": "3",
+    "finger_left_default": "0.8",
+    "finger_right_default": "0.8",
+    "validation_step_size": "0.05",
+    "smoothing_window": "5",
+    "smoothing_passes": "3",
+    "min_r_point": "0.09",
+    "self_filter_distance": "0.12",
+}
+
+
+def _vamp_server_already_running():
+    """Return True if a node named 'vamp_server' is already on the ROS graph.
+
+    Uses `ros2 node list` rather than rclpy so we don't have to spin up (and
+    tear down) a node inside the launch description. Any failure (timeout, ros2
+    not found) is treated as 'not running' so the guard never blocks a
+    legitimate launch."""
+    try:
+        result = subprocess.run(
+            ["ros2", "node", "list"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return False
+    return any(
+        line.strip().rsplit("/", 1)[-1] == "vamp_server"
+        for line in result.stdout.splitlines()
     )
+
+
+def launch_setup(context, *args, **kwargs):
+    force = LaunchConfiguration("force").perform(context).lower() in ("true", "1")
+
+    if not force and _vamp_server_already_running():
+        print(
+            "[vamp_server.launch] A 'vamp_server' node is already running — "
+            "skipping this instance to avoid a duplicate-name collision. "
+            "Pass force:=true to start another anyway."
+        )
+        return []
+
+    return [
+        Node(
+            package="vamp_moveit_plugin",
+            executable="vamp_server.py",
+            name="vamp_server",
+            output="screen",
+            parameters=[
+                {name: LaunchConfiguration(name) for name in _SERVER_PARAMS}
+            ],
+        )
+    ]
+
+
+def generate_launch_description():
+    arg_descriptions = {
+        "max_iterations": "Max RRT iterations per attempt",
+        "range": "RRT extension range in C-space",
+        "security_margin": "Extra collision margin (meters)",
+        "max_retries": "Number of planning retries with increasing params",
+        "finger_left_default": "Default left finger joint value",
+        "finger_right_default": "Default right finger joint value",
+        "validation_step_size": "Interpolation step for path validation (radians)",
+        "smoothing_window": "Moving average window for path smoothing",
+        "smoothing_passes": "Number of smoothing passes",
+        "min_r_point": "Minimum collision radius per voxel (compensates sphere model)",
+        "self_filter_distance": "Distance to filter robot body from pointcloud (meters)",
+    }
+
+    declared_args = [
+        DeclareLaunchArgument(name, default_value=default, description=arg_descriptions[name])
+        for name, default in _SERVER_PARAMS.items()
+    ]
+    declared_args.append(
+        DeclareLaunchArgument(
+            "force",
+            default_value="false",
+            description="Start vamp_server even if one is already running (bypasses the singleton guard)",
+        )
+    )
+
+    return LaunchDescription(declared_args + [OpaqueFunction(function=launch_setup)])

--- a/manipulation/packages/vamp_moveit_plugin/launch/vamp_server.launch.py
+++ b/manipulation/packages/vamp_moveit_plugin/launch/vamp_server.launch.py
@@ -48,12 +48,8 @@ _SERVER_PARAMS = {
 
 
 def _vamp_server_already_running():
-    """Return True if a node named 'vamp_server' is already on the ROS graph.
-
-    Uses `ros2 node list` rather than rclpy so we don't have to spin up (and
-    tear down) a node inside the launch description. Any failure (timeout, ros2
-    not found) is treated as 'not running' so the guard never blocks a
-    legitimate launch."""
+    """True if a 'vamp_server' node is already on the ROS graph (via `ros2 node list`).
+    Fails open: any error (timeout, ros2 missing) returns False so the guard never blocks a launch."""
     try:
         result = subprocess.run(
             ["ros2", "node", "list"],


### PR DESCRIPTION
## Summary

- Both `frida_fake_moveit_config.launch.py` and `frida_moveit_config.launch.py` set the **`vamp` pipeline as the default planner** (via `VampPlannerManager`), but neither launch ever started the `vamp_server.py` backend that the plugin delegates to.
- Consequence: every first plan waited ~3s for the unavailable VAMP service, timed out, and fell back to OMPL — so VAMP was effectively never used out of the box despite being the configured default.
- Both launches now include `vamp_server.launch.py`, gated by a new **`start_vamp_server` argument (default `true`)**. The include reuses the existing launch file rather than duplicating its parameter declarations.
- `vamp_server.launch.py` is now a **singleton**: it checks the ROS graph at startup and skips launching when a `vamp_server` node already exists, so starting it both from the moveit config and by hand no longer creates a duplicate-name collision.

## Behavior

| Command | Result |
|---|---|
| `ros2 launch arm_pkg frida_fake_moveit_config.launch.py` | move_group + **vamp_server** both start; VAMP planning works immediately |
| `... start_vamp_server:=false` | vamp_server not started; exercises OMPL fallback, or lets you run the server separately/remotely |
| `ros2 launch vamp_moveit_plugin vamp_server.launch.py` while one is already running | Detects the existing node and **skips** (logs why); `force:=true` overrides |

Same `start_vamp_server` argument on the real `frida_moveit_config.launch.py`.

## Implementation

- Inclusion uses the same `IncludeLaunchDescription` + `PathJoinSubstitution(FindPackageShare(...))` pattern already used in these files for `robot_description_launch`, `robot_moveit_common_launch`, `ros2_control_launch`, and `downsample_pcd`, wrapped with `IfCondition(LaunchConfiguration("start_vamp_server", default="true"))`.
- The singleton guard checks `ros2 node list` from an `OpaqueFunction`; it **fails open** (any error → treated as "not running") so it can never block a legitimate launch. A `force:=true` argument bypasses it.
- `vamp_server.launch.py` parameter declarations were refactored into a single source-of-truth dict so the node params and the `DeclareLaunchArgument` list stay in sync.

## Test status

- [x] All three touched files pass `python3 -m py_compile`.
- [x] Singleton-detection parsing unit-checked: empty graph → launch; `/vamp_server` present → skip; `/foo_vamp_server_x` → no false match; `/ns/vamp_server` → detected.
- [x] Inclusion mirrors the proven `IncludeLaunchDescription`/`IfCondition` pattern already in these files.
- [ ] **Live launch not run in this PR** — the laptop container used for development is in a partial build state (`arm_pkg` not installed), so a full `ros2 launch` integration test requires a clean `./run.sh manipulation --build`. Recommend validating on a built workspace (Orin or freshly-built laptop): confirm `/vamp_server` appears in `ros2 node list` after launch; `start_vamp_server:=false` omits it; and a manual `ros2 launch ... vamp_server.launch.py` on top is skipped by the guard.

## Files

| File | Change |
|---|---|
| `arm_pkg/launch/frida_fake_moveit_config.launch.py` | Import `IfCondition`; include `vamp_server.launch.py` gated by `start_vamp_server` (default true) |
| `arm_pkg/launch/frida_moveit_config.launch.py` | Same, for the real-hardware launch |
| `vamp_moveit_plugin/launch/vamp_server.launch.py` | Singleton guard (skip if already running, `force:=true` to override); params refactored to a single dict |
| `vamp_moveit_plugin/ReadMe.md` | Step 3 updated: vamp_server auto-starts; document the `start_vamp_server:=false` escape hatch |