### PR TITLE
Seed VAMP start state from current scene state (fix inf start on real hardware)

### DIFF
--- a/manipulation/packages/vamp_moveit_plugin/src/vamp_planning_context.cpp
+++ b/manipulation/packages/vamp_moveit_plugin/src/vamp_planning_context.cpp
@@ -208,7 +208,9 @@ bool VampPlanningContext::solve(planning_interface::MotionPlanResponse& res)
 
   
   std::vector<double> start_state;
-  moveit::core::RobotState start_robot_state(robot_model_);
+  // Seed from the current scene state so joints absent from req.start_state (partial or
+  // is_diff requests, e.g. from RViz) keep real values instead of uninitialized garbage.
+  moveit::core::RobotState start_robot_state = getPlanningScene()->getCurrentState();
   moveit::core::robotStateMsgToRobotState(req.start_state, start_robot_state);
   const moveit::core::JointModelGroup* jmg =
       start_robot_state.getJointModelGroup(getGroupName());


### PR DESCRIPTION
## Summary

- `VampPlanningContext::solve` built the start `RobotState` with the bare `RobotState(robot_model_)` constructor, which leaves variable positions **uninitialized**.
- `robotStateMsgToRobotState` only fills joints present in `req.start_state`. For partial or `is_diff` start states (e.g. what RViz sends on real hardware), the missing joints kept garbage values — observed as **`inf` on joints 1/5/6**, overflowing the `float32` cast in `vamp_server` (`overflow encountered in cast`).
- VAMP then rejected every start as out-of-limits (`Start INVALID (joint1=inf ...)`) and silently fell back to OMPL — so **VAMP never actually planned on the real robot from RViz**, despite being the configured default planner.

## Fix

Seed the state from `getPlanningScene()->getCurrentState()` (the live robot state) before applying `req.start_state`, so any joint absent from the message keeps its real value instead of uninitialized memory.

```cpp
// before
moveit::core::RobotState start_robot_state(robot_model_);
moveit::core::robotStateMsgToRobotState(req.start_state, start_robot_state);

// after
moveit::core::RobotState start_robot_state = getPlanningScene()->getCurrentState();
moveit::core::robotStateMsgToRobotState(req.start_state, start_robot_state);
```

The goal path was unaffected because it is parsed directly from `joint_constraints`, not from a `RobotState` — which is why goals were always valid while starts came through as `inf`.

## Test (real xArm6, found during Tier 4 R6)

Before — start arrives as `inf`, VAMP rejects, OMPL fallback:
```
Start: [inf, 0.0, 0.0, 6.5e-38, inf, inf]
Start INVALID (joint1=inf outside [-6.283, 6.283]; ...)
VAMP planning failed — trying OMPL fallback
```

After — real start values, VAMP plans, no fallback, executes at velocity scaling 1.0:
```
Start: [-1.5709, -1.3966, -1.2217, -0.0004, 1.0467, 0.7842]
RRTConnect (attempt 1): 0.51 ms
Solved on attempt 1
SUCCESS | 20 waypoints | total=8.6 ms
[xarm6_traj_controller] Goal reached, success!
```

- [x] `colcon build --packages-select vamp_moveit_plugin` clean (17.8s, aarch64 Orin).
- [x] Real xArm6: VAMP plans (8.6 ms) and executes a full-velocity trajectory with no fault and no OMPL fallback (Tier 4 R6).