### PR TITLE
Fix vamp_server crash under symlink-install (abspath -> realpath)

### DIFF
--- a/manipulation/packages/vamp_moveit_plugin/scripts/vamp_server.py
+++ b/manipulation/packages/vamp_moveit_plugin/scripts/vamp_server.py
@@ -22,7 +22,7 @@ from ament_index_python.packages import get_package_share_directory
 from vamp_moveit_plugin.srv import VampPlan
 import numpy as np
 
-actual_dir = os.path.dirname(os.path.abspath(__file__))
+actual_dir = os.path.dirname(os.path.realpath(__file__))
 ruta_vamp = os.path.abspath(os.path.join(actual_dir, "../../vamp/src"))
 sys.path.append(ruta_vamp)
 import vamp  # noqa: E402 — VAMP bindings live in submodule src/, must extend sys.path first


### PR DESCRIPTION
## Problem

When `frida_moveit_config` launches, it auto-starts `vamp_server.py` (the VAMP planning backend). The node crashed immediately on startup with:

```
ModuleNotFoundError: No module named 'vamp'
```

so the `plan_vamp_path` service never came up, and every plan reported *"VAMP server unavailable! Is vamp_server.py running?"* and fell back to OMPL.

## Root cause

`vamp_server.py` locates the VAMP bindings relative to `os.path.abspath(__file__)`, which does **not** resolve symlinks. Under `colcon build --symlink-install`, ros2 launches the installed symlink and `abspath` keeps the install path, so `../../vamp/src` resolved to a nonexistent `install/vamp_moveit_plugin/vamp/src` instead of the real source tree.

It only appeared to work in some shells because `PYTHONPATH` (exported by `setup_vamp.sh` / `.bash_aliases`) masked the broken fallback — but that export is fragile (lost across the subshell in `run.sh`, and absent in non-interactive launch processes), so the node crashed whenever the launch didn't inherit it.

## Fix

Use `os.path.realpath(__file__)` so the symlink resolves back to the source tree and the `sys.path` entry is correct regardless of how the script is launched or whether `PYTHONPATH` is set.

## Verification

Reproduced and verified on the Jetson Orin with a live `frida_moveit_config` launch (and with `PYTHONPATH` unset): the `vamp_server` node stays alive, `/plan_vamp_path` is available, and the *"Is vamp_server.py running?"* error no longer occurs.