### PR TITLE
Restore OMPL as default planner and fix octomap_resolution for small-object grasps

### DIFF
--- a/manipulation/packages/arm_pkg/launch/frida_moveit_common.launch.py
+++ b/manipulation/packages/arm_pkg/launch/frida_moveit_common.launch.py
@@ -74,7 +74,9 @@ def launch_setup(context, *args, **kwargs):
 
     octomap_config = {
         "octomap_frame": "base_link",
-        "octomap_resolution": 0.05,
+        # Restored to pre-#977 value: at 0.05 m, padded voxels cover small
+        # grasp goals (~6-7 cm objects) and FCL rejects the gripper pose.
+        "octomap_resolution": 0.025,
         "max_range": 2.0,
     }
 

--- a/manipulation/packages/arm_pkg/launch/frida_moveit_config.launch.py
+++ b/manipulation/packages/arm_pkg/launch/frida_moveit_config.launch.py
@@ -147,7 +147,10 @@ def launch_setup(context, *args, **kwargs):
             geometry_mesh_tcp_rpy=geometry_mesh_tcp_rpy,
         )
         .planning_pipelines(
-            pipelines=["vamp", "ompl"], default_planning_pipeline="vamp"
+            # Default "ompl": VAMP needs retuning before it can be default
+            # again (its self-filter masks goal voxels FCL keeps -> rejection).
+            pipelines=["vamp", "ompl"],
+            default_planning_pipeline="ompl",
         )
         .to_moveit_configs()
     )
@@ -256,8 +259,8 @@ def launch_setup(context, *args, **kwargs):
         ],
     )
 
-    # Start the VAMP backend ("vamp" is the default planner; without it every plan
-    # waits ~3s then falls back to OMPL). Disable with start_vamp_server:=false.
+    # VAMP backend off by default (pipeline above is "ompl"). Re-enable with
+    # start_vamp_server:=true and flip the default pipeline back to "vamp".
     vamp_server_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(
@@ -268,7 +271,9 @@ def launch_setup(context, *args, **kwargs):
                 ]
             )
         ),
-        condition=IfCondition(LaunchConfiguration("start_vamp_server", default="true")),
+        condition=IfCondition(
+            LaunchConfiguration("start_vamp_server", default="false")
+        ),
     )
 
     return [


### PR DESCRIPTION
## TL;DR

Picks and places stopped working on the real xArm6 after PR #977. Two launch-time params introduced by that PR (`octomap_resolution: 0.025 -> 0.05` and `default_planning_pipeline: ompl -> vamp`) made the gripper at any grasp pose collide with the target object's own octomap voxels, so FCL rejects the goal. This PR reverts those two values and disables `vamp_server` by default. VAMP is not removed — it stays available behind a launch arg until it can be retuned.

## Bug

- **Symptom**: `RRTConnect: Unable to sample any valid states for goal tree` for every grasp pose, ~8-14 s wasted per pick, eventual `Failed to reach any grasp pose`.
- **Cause**: at `octomap_resolution=0.05` with the existing padding (`offset 0.03`, `scale 1.05`), each voxel inflates to ~12-14 cm of effective collision geometry. Tabletop objects (~6 cm orange, ~7 cm apple) are fully covered by their own voxels, so any grasp pose has the gripper inside obstacle space.
- **Why VAMP "hid" it**: VAMP's `self_filter_distance=0.12` strips those voxels from VAMP's collision model at the goal config, so VAMP plans "successfully" — then `VampPlannerManager` runs FCL post-validation, which fails. The OMPL fallback inside the plugin hits the same FCL goal-sampling failure.

Bisect confirmed regression entered at commit `6cd26cc3` (PR #977, 2026-05-23).

## Fix

| File | Change |
|---|---|
| `arm_pkg/launch/frida_moveit_common.launch.py` | `octomap_resolution: 0.05` -> `0.025` |
| `arm_pkg/launch/frida_moveit_config.launch.py` | `default_planning_pipeline: vamp` -> `ompl` |
| `arm_pkg/launch/frida_moveit_config.launch.py` | `start_vamp_server` default: `true` -> `false` |

To experiment with VAMP again: edit the default pipeline back to `vamp` and launch with `start_vamp_server:=true`.

## Verification

`ros2 launch manipulation_general ppc.launch.py` on the real FRIDA xArm6. Triggered pick + place via `keyboard_input`:

- Pick (orange / apple): 2/3 successful — same iterative behavior as the pre-#977 working commit (`Demo/roborregos day`).
- Place: 2/2 successful.
- No `vamp_server` running; all plans go through plain OMPL.

## Follow-up

VAMP can be the default again once its sphere model is calibrated for fine grasps instead of navigation-scale obstacles. Suggested starting points: `r_point ~0.03-0.04 m` (currently 0.09), `self_filter_distance ~0.05-0.08 m` (currently 0.12), and `padding_offset/scale -> 0/1` in `sensors_3d.yaml`.