### PR TITLE
fix Dockers build image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# Docker build context exclusions
+
+# Source Control
+.git
+.gitmodules
+.githooks
+
+# Build & Cache
+**/build/
+**/install/
+**/log/
+**/devel/
+**/.vscode/
+**/__pycache__/
+**/.pytest_cache/
+**/.ruff_cache/
+**/.clj-kondo/
+**/.lsp/
+**/baml_client/
+
+# Node.js
+**/node_modules/
+
+# ML / Heavy Caches
+**/trt_cache/
+**/moondream_cache/
+**/chromadb/
+**/.cache/
+*.pt
+*.pth
+*.engine
+*.onnx
+*.whl
+
+# Large Assets (Mounted via volumes, not needed in image)
+hri/packages/nlp/assets/**
+!hri/packages/nlp/assets/Modelfile
+!hri/packages/nlp/assets/NewModelfile
+
+# SQL dumps
+docker/hri/sql_dumps/
+
+# Temporary / OS files
+.DS_Store
+Thumbs.db
+*.bag
+*.traj
+cyclonedds.log

--- a/docker/integration/Dockerfile
+++ b/docker/integration/Dockerfile
@@ -15,13 +15,14 @@ RUN baml-cli generate
 
 WORKDIR /workspace
 
-COPY ./ /workspace/src
-RUN sudo apt update && sudo rosdep init && rosdep update
-RUN rosdep install --from-paths ./src/task_manager --ignore-src -y -r
+# Use specific packages instead of copying everything to keep the image small
+COPY task_manager /workspace/src/task_manager
+COPY frida_constants /workspace/src/frida_constants
+COPY frida_interfaces /workspace/src/frida_interfaces
+
+RUN sudo apt update && (sudo rosdep init || true) && rosdep update
+RUN rosdep install --from-paths /workspace/src --ignore-src -y -r
 RUN sudo rm -rf /workspace/src/
-# CV-bridge
-RUN apt update
-RUN apt install -y ros-humble-nav2-msgs
 
 # CycloneDDS
 RUN sudo apt-get update -qq && sudo apt-get install -y -qq ros-humble-rmw-cyclonedds-cpp \

--- a/docker/integration/Dockerfile
+++ b/docker/integration/Dockerfile
@@ -15,7 +15,6 @@ RUN baml-cli generate
 
 WORKDIR /workspace
 
-# Use specific packages instead of copying everything to keep the image small
 COPY task_manager /workspace/src/task_manager
 COPY frida_constants /workspace/src/frida_constants
 COPY frida_interfaces /workspace/src/frida_interfaces


### PR DESCRIPTION
no more infinite transferring context and exporting to image wait times.

Copy only specific packages in integration's Dockerfile to take more advantage of layer caching