### PR TITLE
Pick basket

### DIFF
--- a/frida_constants/frida_constants/manipulation_constants.py
+++ b/frida_constants/frida_constants/manipulation_constants.py
@@ -73,7 +73,7 @@ GRASP_LINK_FRAME = "gripper_grasp_frame"
 
 # Basket (floor pick by the rim/edge, top-down straddle grasp)
 BASKET_NAMES = ["basket", "aundry_basket"]
-BASKET_PRE_GRASP_HEIGHT = 0.20  # m above the rim for the MoveIt pre-grasp
+BASKET_PRE_GRASP_HEIGHT = 0.10  # m above the rim for the MoveIt pre-grasp
 BASKET_GRASP_Z_TWEAK = (
     -0.03
 )  # m: target ~3 cm below rim top so fingers straddle the wall

--- a/frida_constants/frida_constants/manipulation_constants.py
+++ b/frida_constants/frida_constants/manipulation_constants.py
@@ -71,15 +71,12 @@ CUTLERY_NAMES = ["fork", "knife", "spoon", "cutlery"]
 POUR_OBJECT_NAMES = {"blue_cereal_box", "cereal", "chocomilk_box", "milk"}
 GRASP_LINK_FRAME = "gripper_grasp_frame"
 
-# Basket (floor pick by the rim/edge, top-down straddle grasp)
-BASKET_NAMES = ["basket", "aundry_basket"]
-BASKET_PRE_GRASP_HEIGHT = 0.10  # m above the rim for the MoveIt pre-grasp
-BASKET_GRASP_Z_TWEAK = (
-    -0.03
-)  # m: target ~3 cm below rim top so fingers straddle the wall
-BASKET_DESCENT_SPEED = 20.0  # mm/s downward (xArm cartesian-velocity convention)
-# Fixed descent distance from the pre-grasp down to the grasp point (no force feedback)
-BASKET_DESCENT_DISTANCE = BASKET_PRE_GRASP_HEIGHT - BASKET_GRASP_Z_TWEAK  # = 0.23 m
+# Rim pick
+RIM_NAMES = ["basket", "aundry_basket", "laundry_basket"]
+RIM_PRE_GRASP_HEIGHT = 0.10
+RIM_GRASP_Z_TWEAK = -0.03  # m: target ~3 cm below rim top so fingers straddle the wall
+RIM_DESCENT_SPEED = 20.0  # mm/s
+RIM_DESCENT_DISTANCE = RIM_PRE_GRASP_HEIGHT - RIM_GRASP_Z_TWEAK
 
 # Place
 PLACE_PERCEPTION_SERVICE = "/manipulation/place_perception_service"

--- a/frida_constants/frida_constants/manipulation_constants.py
+++ b/frida_constants/frida_constants/manipulation_constants.py
@@ -71,6 +71,16 @@ CUTLERY_NAMES = ["fork", "knife", "spoon", "cutlery"]
 POUR_OBJECT_NAMES = {"blue_cereal_box", "cereal", "chocomilk_box", "milk"}
 GRASP_LINK_FRAME = "gripper_grasp_frame"
 
+# Basket (floor pick by the rim/edge, top-down straddle grasp)
+BASKET_NAMES = ["basket", "laundry_basket"]
+BASKET_PRE_GRASP_HEIGHT = 0.20  # m above the rim for the MoveIt pre-grasp
+BASKET_GRASP_Z_TWEAK = (
+    -0.03
+)  # m: target ~3 cm below rim top so fingers straddle the wall
+BASKET_DESCENT_SPEED = 20.0  # mm/s downward (xArm cartesian-velocity convention)
+# Fixed descent distance from the pre-grasp down to the grasp point (no force feedback)
+BASKET_DESCENT_DISTANCE = BASKET_PRE_GRASP_HEIGHT - BASKET_GRASP_Z_TWEAK  # = 0.23 m
+
 # Place
 PLACE_PERCEPTION_SERVICE = "/manipulation/place_perception_service"
 HEATMAP_PLACE_SERVICE = "/manipulation/heatmap_place_service"

--- a/frida_constants/frida_constants/manipulation_constants.py
+++ b/frida_constants/frida_constants/manipulation_constants.py
@@ -72,7 +72,7 @@ POUR_OBJECT_NAMES = {"blue_cereal_box", "cereal", "chocomilk_box", "milk"}
 GRASP_LINK_FRAME = "gripper_grasp_frame"
 
 # Basket (floor pick by the rim/edge, top-down straddle grasp)
-BASKET_NAMES = ["basket", "laundry_basket"]
+BASKET_NAMES = ["basket", "aundry_basket"]
 BASKET_PRE_GRASP_HEIGHT = 0.20  # m above the rim for the MoveIt pre-grasp
 BASKET_GRASP_Z_TWEAK = (
     -0.03

--- a/frida_constants/frida_constants/manipulation_constants.py
+++ b/frida_constants/frida_constants/manipulation_constants.py
@@ -74,7 +74,7 @@ GRASP_LINK_FRAME = "gripper_grasp_frame"
 # Rim pick
 RIM_NAMES = ["basket", "aundry_basket", "laundry_basket"]
 RIM_PRE_GRASP_HEIGHT = 0.10
-RIM_GRASP_Z_TWEAK = -0.03  # m: target ~3 cm below rim top so fingers straddle the wall
+RIM_GRASP_Z_TWEAK = -0.05  # m: target ~3 cm below rim top so fingers straddle the wall
 RIM_DESCENT_SPEED = 20.0  # mm/s
 RIM_DESCENT_DISTANCE = RIM_PRE_GRASP_HEIGHT - RIM_GRASP_Z_TWEAK
 

--- a/frida_constants/frida_constants/xarm_configurations.py
+++ b/frida_constants/frida_constants/xarm_configurations.py
@@ -181,9 +181,9 @@ SCAN_FLOOR_CARRY_BAG_POSE = {
     "degrees": True,
 }
 
-LOOK_BACK_STARE = {
+LOOK_SIDE_STARE = {
     "joints": {
-        "joint1": 90.0,
+        "joint1": -180.0,
         "joint2": -70.0,
         "joint3": -45.0,
         "joint4": 0.0,
@@ -209,5 +209,5 @@ XARM_CONFIGURATIONS = {
     "place_floor_left": PLACE_FLOOR_LEFT,
     "hand_bag_pose": HAND_BAG_POSE,
     "scan_floor_carry_bag_pose": SCAN_FLOOR_CARRY_BAG_POSE,
-    "look_back_stare": LOOK_BACK_STARE,
+    "look_side_stare": LOOK_SIDE_STARE,
 }

--- a/frida_constants/frida_constants/xarm_configurations.py
+++ b/frida_constants/frida_constants/xarm_configurations.py
@@ -181,6 +181,18 @@ SCAN_FLOOR_CARRY_BAG_POSE = {
     "degrees": True,
 }
 
+LOOK_BACK_STARE = {
+    "joints": {
+        "joint1": 90.0,
+        "joint2": -70.0,
+        "joint3": -45.0,
+        "joint4": 0.0,
+        "joint5": 30.0,
+        "joint6": 45.0,
+    },
+    "degrees": True,
+}
+
 XARM_CONFIGURATIONS = {
     "front_stare": FRONT_STARE,
     "front_low_stare": FRONT_LOW_STARE,
@@ -197,4 +209,5 @@ XARM_CONFIGURATIONS = {
     "place_floor_left": PLACE_FLOOR_LEFT,
     "hand_bag_pose": HAND_BAG_POSE,
     "scan_floor_carry_bag_pose": SCAN_FLOOR_CARRY_BAG_POSE,
+    "look_back_stare": LOOK_BACK_STARE,
 }

--- a/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
+++ b/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
@@ -18,6 +18,7 @@ from frida_constants.vision_constants import (
     DEPTH_IMAGE_TOPIC,
     CAMERA_INFO_TOPIC,
 )
+from frida_constants.manipulation_constants import RIM_NAMES
 
 from frida_interfaces.msg import ObjectDetectionArray, ObjectDetection
 
@@ -33,13 +34,12 @@ TABLE_HEIGHT_BUFFER_SIZE = 15
 # Maximum allowed deviation from the running median (reject outliers)
 TABLE_HEIGHT_OUTLIER_THRESH = 0.015  # 15mm
 
-# --- Basket (rim/edge) grasp estimation ---
-# Minimum height above the detected floor for a point to count as basket (not floor)
+# --- Rim grasp estimation ---
 RIM_MIN_HEIGHT = 0.05  # m
 # Fraction of points closest to the base used to estimate the near rim point
-BASKET_NEAR_FRACTION = 0.05
+RIM_NEAR_FRACTION = 0.05
 # Percentile of Z used as the rim-top height (robust to a few high outliers)
-BASKET_TOP_PERCENTILE = 90
+RIM_TOP_PERCENTILE = 90
 # Vertical band below the rim-top kept as the rim ring (meters)
 RIM_TOP_BAND = 0.03
 
@@ -59,7 +59,7 @@ class FlatGraspEstimator(Node):
         self.depth_frame_id = "zed_left_camera_optical_frame"
 
         self.target_classes = ["spoon", "fork", "knife"]
-        self.basket_classes = ["aundry_basket", "basket"]
+        self.rim_classes = list(RIM_NAMES)
 
         # Start disabled — only enabled explicitly before a cutlery pick.
         # Saves CPU/network when no manipulation is in progress.
@@ -83,8 +83,8 @@ class FlatGraspEstimator(Node):
             PoseStamped, "/manipulation/flat_grasp_pose", 10
         )
 
-        self.basket_pose_pub = self.create_publisher(
-            PoseStamped, "/manipulation/basket_grasp_pose", 10
+        self.rim_pose_pub = self.create_publisher(
+            PoseStamped, "/manipulation/rim_grasp_pose", 10
         )
 
         self.enable_srv = self.create_service(
@@ -131,8 +131,8 @@ class FlatGraspEstimator(Node):
             label = det.label_text.lower()
             if label in self.target_classes:
                 self.process_flat_object(det)
-            elif label in self.basket_classes:
-                self.process_basket_object(det)
+            elif label in self.rim_classes:
+                self.process_rim_object(det)
 
     def get_stable_table_height(self, new_reading):
         """Add a new table height reading and return a stable averaged value.
@@ -282,20 +282,14 @@ class FlatGraspEstimator(Node):
         grasp_pose.pose.orientation.w = new_quat[3]
 
         self.pose_pub.publish(grasp_pose)
-        self.get_logger().info(
-            f"Grasp (link_base): X={centroid_xy[0]:.3f}, "
-            f"Y={centroid_xy[1]:.3f}, Z={grasp_z:.4f} "
-            f"(raw_table={raw_table_height:.4f}, stable_table={stable_table_height:.4f}, "
-            f"buf={len(self.table_height_buffer)})"
-        )
 
-    def process_basket_object(self, detection: ObjectDetection):
-        """Estimate a top-down grasp on the near rim/edge of a basket on the floor.
+    def process_rim_object(self, detection: ObjectDetection):
+        """Estimate a top-down grasp on the near rim.
 
         Deprojects the whole detection bbox into a 3D prism, transforms it to the
         base frame, rejects the floor, and selects the point closest to the base
         (the near rim). The grasp is oriented so the gripper fingers close radially
-        across the rim wall (one finger inside, one outside the basket).
+        across the rim wall (one finger inside, one outside).
         """
         h_img, w_img = self.latest_depth.shape
 
@@ -371,29 +365,26 @@ class FlatGraspEstimator(Node):
 
         # --- FLOOR REJECTION ---
         # The floor is the lowest surface in the frustum; keep only points that sit
-        # clearly above it so nearer floor returns aren't mistaken for the rim.
         floor_z = np.percentile(points_base[:, 2], 5)
         rim_mask = points_base[:, 2] > floor_z + RIM_MIN_HEIGHT
         rim_points = points_base[rim_mask]
         if len(rim_points) < MIN_POINTS_FOR_PCA:
             self.get_logger().warn(
-                "Not enough basket points above the floor for a rim estimate"
+                "Not enough rim points above the floor for a rim estimate"
             )
             return
 
         # --- RIM TOP RING ---
-        # The rim is the TOP edge of the basket. Selecting points purely by horizontal
-        # distance picks the whole near wall (top..floor), whose median Z lands near the
-        # wall middle -> the grasp would descend far below the rim. Anchor to the top:
+        # The rim is the TOP edge of the object. Anchor to the top:
         # take the rim-top height as a high Z percentile and keep only the top ring.
-        top_z = np.percentile(rim_points[:, 2], BASKET_TOP_PERCENTILE)
+        top_z = np.percentile(rim_points[:, 2], RIM_TOP_PERCENTILE)
         top_ring = rim_points[rim_points[:, 2] > top_z - RIM_TOP_BAND]
         if len(top_ring) < MIN_POINTS_FOR_PCA:
             top_ring = rim_points
 
         # --- NEAR RIM POINT (closest to base, along the top ring) ---
         horiz_dist = np.sqrt(top_ring[:, 0] ** 2 + top_ring[:, 1] ** 2)
-        k = max(MIN_POINTS_FOR_PCA, int(BASKET_NEAR_FRACTION * len(horiz_dist)))
+        k = max(MIN_POINTS_FOR_PCA, int(RIM_NEAR_FRACTION * len(horiz_dist)))
         k = min(k, len(horiz_dist))
         near_idx = np.argsort(horiz_dist)[:k]
         rim_point = np.median(top_ring[near_idx], axis=0)
@@ -411,7 +402,7 @@ class FlatGraspEstimator(Node):
             return
         radial = radial / radial_norm
 
-        # Gripper local Y is the finger-closing axis (same convention as the flat path).
+        # Gripper local Y is the finger-closing axis.
         Y_grasp = radial
         X_grasp = np.cross(Y_grasp, Z_grasp)
         X_grasp = X_grasp / np.linalg.norm(X_grasp)
@@ -434,12 +425,7 @@ class FlatGraspEstimator(Node):
         grasp_pose.pose.orientation.z = new_quat[2]
         grasp_pose.pose.orientation.w = new_quat[3]
 
-        self.basket_pose_pub.publish(grasp_pose)
-        self.get_logger().info(
-            f"Basket rim grasp (link_base): X={rim_x:.3f}, Y={rim_y:.3f}, "
-            f"Z={rim_z:.4f} (floor_z={floor_z:.4f}, top_z={top_z:.4f}, "
-            f"rim_pts={len(rim_points)}, top_ring={len(top_ring)}, near_k={k})"
-        )
+        self.rim_pose_pub.publish(grasp_pose)
 
 
 def main(args=None):

--- a/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
+++ b/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
@@ -33,6 +33,12 @@ TABLE_HEIGHT_BUFFER_SIZE = 15
 # Maximum allowed deviation from the running median (reject outliers)
 TABLE_HEIGHT_OUTLIER_THRESH = 0.015  # 15mm
 
+# --- Basket (rim/edge) grasp estimation ---
+# Minimum height above the detected floor for a point to count as basket (not floor)
+RIM_MIN_HEIGHT = 0.05  # m
+# Fraction of points closest to the base used to estimate the near rim point
+BASKET_NEAR_FRACTION = 0.05
+
 
 class FlatGraspEstimator(Node):
     def __init__(self):
@@ -49,6 +55,7 @@ class FlatGraspEstimator(Node):
         self.depth_frame_id = "zed_left_camera_optical_frame"
 
         self.target_classes = ["spoon", "fork", "knife"]
+        self.basket_classes = ["laundry_basket", "basket"]
 
         # Start disabled — only enabled explicitly before a cutlery pick.
         # Saves CPU/network when no manipulation is in progress.
@@ -70,6 +77,10 @@ class FlatGraspEstimator(Node):
 
         self.pose_pub = self.create_publisher(
             PoseStamped, "/manipulation/flat_grasp_pose", 10
+        )
+
+        self.basket_pose_pub = self.create_publisher(
+            PoseStamped, "/manipulation/basket_grasp_pose", 10
         )
 
         self.enable_srv = self.create_service(
@@ -113,8 +124,11 @@ class FlatGraspEstimator(Node):
         if self.latest_depth is None or self.intrinsics is None:
             return
         for det in msg.detections:
-            if det.label_text.lower() in self.target_classes:
+            label = det.label_text.lower()
+            if label in self.target_classes:
                 self.process_flat_object(det)
+            elif label in self.basket_classes:
+                self.process_basket_object(det)
 
     def get_stable_table_height(self, new_reading):
         """Add a new table height reading and return a stable averaged value.
@@ -269,6 +283,148 @@ class FlatGraspEstimator(Node):
             f"Y={centroid_xy[1]:.3f}, Z={grasp_z:.4f} "
             f"(raw_table={raw_table_height:.4f}, stable_table={stable_table_height:.4f}, "
             f"buf={len(self.table_height_buffer)})"
+        )
+
+    def process_basket_object(self, detection: ObjectDetection):
+        """Estimate a top-down grasp on the near rim/edge of a basket on the floor.
+
+        Deprojects the whole detection bbox into a 3D prism, transforms it to the
+        base frame, rejects the floor, and selects the point closest to the base
+        (the near rim). The grasp is oriented so the gripper fingers close radially
+        across the rim wall (one finger inside, one outside the basket).
+        """
+        h_img, w_img = self.latest_depth.shape
+
+        if detection.xmax <= 1.0 and detection.ymax <= 1.0:
+            xmin = int(max(0, detection.xmin * w_img))
+            ymin = int(max(0, detection.ymin * h_img))
+            xmax = int(min(w_img, detection.xmax * w_img))
+            ymax = int(min(h_img, detection.ymax * h_img))
+        else:
+            xmin = int(max(0, detection.xmin))
+            ymin = int(max(0, detection.ymin))
+            xmax = int(min(w_img, detection.xmax))
+            ymax = int(min(h_img, detection.ymax))
+
+        if xmax <= xmin or ymax <= ymin:
+            return
+
+        roi_depth = self.latest_depth[ymin:ymax, xmin:xmax]
+
+        valid_mask = (roi_depth > 0) & (~np.isnan(roi_depth))
+        if np.count_nonzero(valid_mask) < MIN_POINTS_FOR_PCA:
+            return
+
+        # Whole-frustum prism: deproject every valid pixel in the bbox (no table seg).
+        v_local, u_local = np.where(valid_mask)
+        u_global = u_local + xmin
+        v_global = v_local + ymin
+        z_vals = roi_depth[v_local, u_local]
+
+        fx, fy = self.intrinsics["fx"], self.intrinsics["fy"]
+        cx, cy = self.intrinsics["cx"], self.intrinsics["cy"]
+        x = (u_global - cx) * z_vals / fx
+        y = (v_global - cy) * z_vals / fy
+        points_3d_cam = np.vstack((x, y, z_vals)).T
+
+        # --- TRANSFORM TO BASE FRAME ---
+        try:
+            trans = self.tf_buffer.lookup_transform(
+                self.target_frame,
+                self.depth_frame_id,
+                rclpy.time.Time(),
+                timeout=rclpy.duration.Duration(seconds=1.0),
+            )
+        except Exception as e:
+            self.get_logger().warn(f"Waiting for TF tree from camera to base... {e}")
+            return
+
+        q = [
+            trans.transform.rotation.x,
+            trans.transform.rotation.y,
+            trans.transform.rotation.z,
+            trans.transform.rotation.w,
+        ]
+        t = [
+            trans.transform.translation.x,
+            trans.transform.translation.y,
+            trans.transform.translation.z,
+        ]
+        rot_mat = Rotation.from_quat(q).as_matrix()
+
+        T_mat = np.eye(4)
+        T_mat[:3, :3] = rot_mat
+        T_mat[:3, 3] = t
+
+        points_3d_hom = np.hstack((points_3d_cam, np.ones((points_3d_cam.shape[0], 1))))
+        points_base = (T_mat @ points_3d_hom.T).T[:, :3]
+
+        # Filter out NaN/Inf points
+        finite_mask = np.isfinite(points_base).all(axis=1)
+        points_base = points_base[finite_mask]
+        if len(points_base) < MIN_POINTS_FOR_PCA:
+            return
+
+        # --- FLOOR REJECTION ---
+        # The floor is the lowest surface in the frustum; keep only points that sit
+        # clearly above it so nearer floor returns aren't mistaken for the rim.
+        floor_z = np.percentile(points_base[:, 2], 5)
+        rim_mask = points_base[:, 2] > floor_z + RIM_MIN_HEIGHT
+        rim_points = points_base[rim_mask]
+        if len(rim_points) < MIN_POINTS_FOR_PCA:
+            self.get_logger().warn(
+                "Not enough basket points above the floor for a rim estimate"
+            )
+            return
+
+        # --- NEAR RIM POINT (closest to base) ---
+        horiz_dist = np.sqrt(rim_points[:, 0] ** 2 + rim_points[:, 1] ** 2)
+        k = max(MIN_POINTS_FOR_PCA, int(BASKET_NEAR_FRACTION * len(horiz_dist)))
+        k = min(k, len(horiz_dist))
+        near_idx = np.argsort(horiz_dist)[:k]
+        rim_point = np.median(rim_points[near_idx], axis=0)
+        rim_x, rim_y, rim_z = (
+            float(rim_point[0]),
+            float(rim_point[1]),
+            float(rim_point[2]),
+        )
+
+        # --- STRADDLE ORIENTATION (top-down, fingers close radially across the wall) ---
+        Z_grasp = np.array([0.0, 0.0, -1.0])
+        radial = np.array([rim_x, rim_y, 0.0])
+        radial_norm = np.linalg.norm(radial)
+        if radial_norm < 1e-6:
+            return
+        radial = radial / radial_norm
+
+        # Gripper local Y is the finger-closing axis (same convention as the flat path).
+        Y_grasp = radial
+        X_grasp = np.cross(Y_grasp, Z_grasp)
+        X_grasp = X_grasp / np.linalg.norm(X_grasp)
+        Y_grasp = np.cross(Z_grasp, X_grasp)
+
+        new_rot_mat = np.column_stack((X_grasp, Y_grasp, Z_grasp))
+        new_quat = Rotation.from_matrix(new_rot_mat).as_quat()
+
+        # --- PUBLISH ---
+        grasp_pose = PoseStamped()
+        grasp_pose.header.frame_id = self.target_frame
+        grasp_pose.header.stamp = self.get_clock().now().to_msg()
+
+        grasp_pose.pose.position.x = rim_x
+        grasp_pose.pose.position.y = rim_y
+        grasp_pose.pose.position.z = rim_z
+
+        grasp_pose.pose.orientation.x = new_quat[0]
+        grasp_pose.pose.orientation.y = new_quat[1]
+        grasp_pose.pose.orientation.z = new_quat[2]
+        grasp_pose.pose.orientation.w = new_quat[3]
+
+        self.basket_pose_pub.publish(grasp_pose)
+        self.get_logger().info(
+            f"Basket rim grasp (link_base): X={rim_x:.3f}, Y={rim_y:.3f}, "
+            f"Z={rim_z:.4f} (floor_z={floor_z:.4f}, rim_pts={len(rim_points)}, "
+            f"near_k={k})"
         )
 
 

--- a/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
+++ b/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
@@ -36,9 +36,7 @@ TABLE_HEIGHT_OUTLIER_THRESH = 0.015  # 15mm
 
 # --- Rim grasp estimation ---
 RIM_MIN_HEIGHT = 0.05  # Minimum height above the floor
-RIM_NEAR_FRACTION = (
-    0.05  # Fraction of points closest to the base used to estimate the near rim point
-)
+RIM_NEAR_FRACTION = 0.05  # Fraction of nearest points used to estimate the near rim
 RIM_TOP_PERCENTILE = 90  # Percentile of Z used as the rim-top height
 RIM_TOP_BAND = 0.03  # Vertical band below the rim-top kept as the rim ring (meters)
 

--- a/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
+++ b/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
@@ -35,13 +35,12 @@ TABLE_HEIGHT_BUFFER_SIZE = 15
 TABLE_HEIGHT_OUTLIER_THRESH = 0.015  # 15mm
 
 # --- Rim grasp estimation ---
-RIM_MIN_HEIGHT = 0.05  # m
-# Fraction of points closest to the base used to estimate the near rim point
-RIM_NEAR_FRACTION = 0.05
-# Percentile of Z used as the rim-top height (robust to a few high outliers)
-RIM_TOP_PERCENTILE = 90
-# Vertical band below the rim-top kept as the rim ring (meters)
-RIM_TOP_BAND = 0.03
+RIM_MIN_HEIGHT = 0.05  # Minimum height above the floor
+RIM_NEAR_FRACTION = (
+    0.05  # Fraction of points closest to the base used to estimate the near rim point
+)
+RIM_TOP_PERCENTILE = 90  # Percentile of Z used as the rim-top height
+RIM_TOP_BAND = 0.03  # Vertical band below the rim-top kept as the rim ring (meters)
 
 
 class FlatGraspEstimator(Node):
@@ -146,9 +145,13 @@ class FlatGraspEstimator(Node):
         self.table_height_buffer.append(new_reading)
         return np.median(list(self.table_height_buffer))
 
-    def process_flat_object(self, detection: ObjectDetection):
-        h_img, w_img = self.latest_depth.shape
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
 
+    def _parse_bbox(self, detection: ObjectDetection):
+        """Return (xmin, ymin, xmax, ymax) in pixels, or None if degenerate."""
+        h_img, w_img = self.latest_depth.shape
         if detection.xmax <= 1.0 and detection.ymax <= 1.0:
             xmin = int(max(0, detection.xmin * w_img))
             ymin = int(max(0, detection.ymin * h_img))
@@ -159,12 +162,79 @@ class FlatGraspEstimator(Node):
             ymin = int(max(0, detection.ymin))
             xmax = int(min(w_img, detection.xmax))
             ymax = int(min(h_img, detection.ymax))
-
         if xmax <= xmin or ymax <= ymin:
+            return None
+        return xmin, ymin, xmax, ymax
+
+    def _deproject_pixels(self, u_global, v_global, z_vals) -> np.ndarray:
+        """Deproject image pixels + depth to Nx3 points in camera frame."""
+        fx, fy = self.intrinsics["fx"], self.intrinsics["fy"]
+        cx, cy = self.intrinsics["cx"], self.intrinsics["cy"]
+        x = (u_global - cx) * z_vals / fx
+        y = (v_global - cy) * z_vals / fy
+        return np.vstack((x, y, z_vals)).T
+
+    def _lookup_T_cam_to_base(self):
+        """Return 4x4 homogeneous transform (camera → base), or None on TF failure."""
+        try:
+            trans = self.tf_buffer.lookup_transform(
+                self.target_frame,
+                self.depth_frame_id,
+                rclpy.time.Time(),
+                timeout=rclpy.duration.Duration(seconds=1.0),
+            )
+        except Exception as e:
+            self.get_logger().warn(f"Waiting for TF tree from camera to base... {e}")
+            return None
+        q = [
+            trans.transform.rotation.x,
+            trans.transform.rotation.y,
+            trans.transform.rotation.z,
+            trans.transform.rotation.w,
+        ]
+        t = [
+            trans.transform.translation.x,
+            trans.transform.translation.y,
+            trans.transform.translation.z,
+        ]
+        T = np.eye(4)
+        T[:3, :3] = Rotation.from_quat(q).as_matrix()
+        T[:3, 3] = t
+        return T
+
+    def _apply_transform(self, points_3d_cam: np.ndarray, T_mat: np.ndarray):
+        """Transform Nx3 camera-frame points to base frame. Returns filtered array or None."""
+        hom = np.hstack((points_3d_cam, np.ones((len(points_3d_cam), 1))))
+        points_base = (T_mat @ hom.T).T[:, :3]
+        finite = np.isfinite(points_base).all(axis=1)
+        points_base = points_base[finite]
+        return points_base if len(points_base) >= MIN_POINTS_FOR_PCA else None
+
+    def _make_grasp_pose(self, x: float, y: float, z: float, quat) -> PoseStamped:
+        """Build a stamped PoseStamped in the target frame."""
+        pose = PoseStamped()
+        pose.header.frame_id = self.target_frame
+        pose.header.stamp = self.get_clock().now().to_msg()
+        pose.pose.position.x = x
+        pose.pose.position.y = y
+        pose.pose.position.z = z
+        pose.pose.orientation.x = float(quat[0])
+        pose.pose.orientation.y = float(quat[1])
+        pose.pose.orientation.z = float(quat[2])
+        pose.pose.orientation.w = float(quat[3])
+        return pose
+
+    # ------------------------------------------------------------------
+    # Per-class grasp estimation
+    # ------------------------------------------------------------------
+
+    def process_flat_object(self, detection: ObjectDetection):
+        bbox = self._parse_bbox(detection)
+        if bbox is None:
             return
+        xmin, ymin, xmax, ymax = bbox
 
         roi_depth = self.latest_depth[ymin:ymax, xmin:xmax]
-
         valid_mask = (roi_depth > 0) & (~np.isnan(roi_depth))
         valid_roi = roi_depth[valid_mask]
         if len(valid_roi) < MIN_POINTS_FOR_PCA:
@@ -180,75 +250,37 @@ class FlatGraspEstimator(Node):
             & (roi_depth > table_z_cam - 0.05)
         )
         v_local, u_local = np.where(object_mask_roi)
-
-        use_full_roi = len(v_local) < MIN_POINTS_FOR_PCA
-        if use_full_roi:
+        if len(v_local) < MIN_POINTS_FOR_PCA:
             v_local, u_local = np.where(valid_mask)
 
-        u_global = u_local + xmin
-        v_global = v_local + ymin
-        z_vals = roi_depth[v_local, u_local]
+        points_3d_cam = self._deproject_pixels(
+            u_local + xmin, v_local + ymin, roi_depth[v_local, u_local]
+        )
 
-        fx, fy = self.intrinsics["fx"], self.intrinsics["fy"]
-        cx, cy = self.intrinsics["cx"], self.intrinsics["cy"]
-        x = (u_global - cx) * z_vals / fx
-        y = (v_global - cy) * z_vals / fy
-        points_3d_cam = np.vstack((x, y, z_vals)).T
-
-        # --- TRANSFORM TO BASE FRAME ---
-        try:
-            trans = self.tf_buffer.lookup_transform(
-                self.target_frame,
-                self.depth_frame_id,
-                rclpy.time.Time(),
-                timeout=rclpy.duration.Duration(seconds=1.0),
-            )
-        except Exception as e:
-            self.get_logger().warn(f"Waiting for TF tree from camera to base... {e}")
+        T_mat = self._lookup_T_cam_to_base()
+        if T_mat is None:
             return
-
-        q = [
-            trans.transform.rotation.x,
-            trans.transform.rotation.y,
-            trans.transform.rotation.z,
-            trans.transform.rotation.w,
-        ]
-        t = [
-            trans.transform.translation.x,
-            trans.transform.translation.y,
-            trans.transform.translation.z,
-        ]
-        rot_mat = Rotation.from_quat(q).as_matrix()
-
-        T_mat = np.eye(4)
-        T_mat[:3, :3] = rot_mat
-        T_mat[:3, 3] = t
-
-        points_3d_hom = np.hstack((points_3d_cam, np.ones((points_3d_cam.shape[0], 1))))
-        points_base = (T_mat @ points_3d_hom.T).T[:, :3]
-
-        # Filter out NaN/Inf points
-        valid_mask = np.isfinite(points_base).all(axis=1)
-        points_base = points_base[valid_mask]
-        if len(points_base) < MIN_POINTS_FOR_PCA:
+        points_base = self._apply_transform(points_3d_cam, T_mat)
+        if points_base is None:
             return
 
         # --- GRASP POSITION ---
         centroid_xy = np.mean(points_base[:, :2], axis=0)
 
         # Transform table surface point at bbox center to base frame
-        bbox_center_u = (xmin + xmax) / 2.0
-        bbox_center_v = (ymin + ymax) / 2.0
-        table_x_cam = (bbox_center_u - cx) * table_z_cam / fx
-        table_y_cam = (bbox_center_v - cy) * table_z_cam / fy
-        table_point_cam = np.array([table_x_cam, table_y_cam, table_z_cam, 1.0])
-        table_point_base = T_mat @ table_point_cam
-        raw_table_height = table_point_base[2]
-
-        # Stabilize table height with rolling median + outlier rejection
-        stable_table_height = self.get_stable_table_height(raw_table_height)
-
-        grasp_z = stable_table_height + GRASP_SURFACE_OFFSET
+        fx, fy = self.intrinsics["fx"], self.intrinsics["fy"]
+        cx, cy = self.intrinsics["cx"], self.intrinsics["cy"]
+        bbox_cu, bbox_cv = (xmin + xmax) / 2.0, (ymin + ymax) / 2.0
+        table_point_cam = np.array(
+            [
+                (bbox_cu - cx) * table_z_cam / fx,
+                (bbox_cv - cy) * table_z_cam / fy,
+                table_z_cam,
+                1.0,
+            ]
+        )
+        raw_table_height = (T_mat @ table_point_cam)[2]
+        grasp_z = self.get_stable_table_height(raw_table_height) + GRASP_SURFACE_OFFSET
 
         # --- GRASP ORIENTATION (PCA on XY to find long axis) ---
         points_2d_xy = points_base[:, :2] - centroid_xy
@@ -267,107 +299,40 @@ class FlatGraspEstimator(Node):
         new_rot_mat = np.column_stack((X_grasp, Y_grasp, Z_grasp))
         new_quat = Rotation.from_matrix(new_rot_mat).as_quat()
 
-        # --- PUBLISH ---
-        grasp_pose = PoseStamped()
-        grasp_pose.header.frame_id = self.target_frame
-        grasp_pose.header.stamp = self.get_clock().now().to_msg()
-
-        grasp_pose.pose.position.x = float(centroid_xy[0])
-        grasp_pose.pose.position.y = float(centroid_xy[1])
-        grasp_pose.pose.position.z = float(grasp_z)
-
-        grasp_pose.pose.orientation.x = new_quat[0]
-        grasp_pose.pose.orientation.y = new_quat[1]
-        grasp_pose.pose.orientation.z = new_quat[2]
-        grasp_pose.pose.orientation.w = new_quat[3]
-
-        self.pose_pub.publish(grasp_pose)
+        self.pose_pub.publish(
+            self._make_grasp_pose(
+                float(centroid_xy[0]), float(centroid_xy[1]), float(grasp_z), new_quat
+            )
+        )
 
     def process_rim_object(self, detection: ObjectDetection):
-        """Estimate a top-down grasp on the near rim.
-
-        Deprojects the whole detection bbox into a 3D prism, transforms it to the
-        base frame, rejects the floor, and selects the point closest to the base
-        (the near rim). The grasp is oriented so the gripper fingers close radially
-        across the rim wall (one finger inside, one outside).
-        """
-        h_img, w_img = self.latest_depth.shape
-
-        if detection.xmax <= 1.0 and detection.ymax <= 1.0:
-            xmin = int(max(0, detection.xmin * w_img))
-            ymin = int(max(0, detection.ymin * h_img))
-            xmax = int(min(w_img, detection.xmax * w_img))
-            ymax = int(min(h_img, detection.ymax * h_img))
-        else:
-            xmin = int(max(0, detection.xmin))
-            ymin = int(max(0, detection.ymin))
-            xmax = int(min(w_img, detection.xmax))
-            ymax = int(min(h_img, detection.ymax))
-
-        if xmax <= xmin or ymax <= ymin:
+        """Top-down straddle grasp on the near rim/edge of a cylindrical object."""
+        bbox = self._parse_bbox(detection)
+        if bbox is None:
             return
+        xmin, ymin, xmax, ymax = bbox
 
         roi_depth = self.latest_depth[ymin:ymax, xmin:xmax]
-
         valid_mask = (roi_depth > 0) & (~np.isnan(roi_depth))
         if np.count_nonzero(valid_mask) < MIN_POINTS_FOR_PCA:
             return
 
-        # Whole-frustum prism: deproject every valid pixel in the bbox (no table seg).
+        # Whole-frustum prism: deproject every valid pixel (no table seg).
         v_local, u_local = np.where(valid_mask)
-        u_global = u_local + xmin
-        v_global = v_local + ymin
-        z_vals = roi_depth[v_local, u_local]
+        points_3d_cam = self._deproject_pixels(
+            u_local + xmin, v_local + ymin, roi_depth[v_local, u_local]
+        )
 
-        fx, fy = self.intrinsics["fx"], self.intrinsics["fy"]
-        cx, cy = self.intrinsics["cx"], self.intrinsics["cy"]
-        x = (u_global - cx) * z_vals / fx
-        y = (v_global - cy) * z_vals / fy
-        points_3d_cam = np.vstack((x, y, z_vals)).T
-
-        # --- TRANSFORM TO BASE FRAME ---
-        try:
-            trans = self.tf_buffer.lookup_transform(
-                self.target_frame,
-                self.depth_frame_id,
-                rclpy.time.Time(),
-                timeout=rclpy.duration.Duration(seconds=1.0),
-            )
-        except Exception as e:
-            self.get_logger().warn(f"Waiting for TF tree from camera to base... {e}")
+        T_mat = self._lookup_T_cam_to_base()
+        if T_mat is None:
             return
-
-        q = [
-            trans.transform.rotation.x,
-            trans.transform.rotation.y,
-            trans.transform.rotation.z,
-            trans.transform.rotation.w,
-        ]
-        t = [
-            trans.transform.translation.x,
-            trans.transform.translation.y,
-            trans.transform.translation.z,
-        ]
-        rot_mat = Rotation.from_quat(q).as_matrix()
-
-        T_mat = np.eye(4)
-        T_mat[:3, :3] = rot_mat
-        T_mat[:3, 3] = t
-
-        points_3d_hom = np.hstack((points_3d_cam, np.ones((points_3d_cam.shape[0], 1))))
-        points_base = (T_mat @ points_3d_hom.T).T[:, :3]
-
-        # Filter out NaN/Inf points
-        finite_mask = np.isfinite(points_base).all(axis=1)
-        points_base = points_base[finite_mask]
-        if len(points_base) < MIN_POINTS_FOR_PCA:
+        points_base = self._apply_transform(points_3d_cam, T_mat)
+        if points_base is None:
             return
 
         # --- FLOOR REJECTION ---
-        # The floor is the lowest surface in the frustum; keep only points that sit
         floor_z = np.percentile(points_base[:, 2], 5)
-        rim_mask = points_base[:, 2] > floor_z + RIM_MIN_HEIGHT
-        rim_points = points_base[rim_mask]
+        rim_points = points_base[points_base[:, 2] > floor_z + RIM_MIN_HEIGHT]
         if len(rim_points) < MIN_POINTS_FOR_PCA:
             self.get_logger().warn(
                 "Not enough rim points above the floor for a rim estimate"
@@ -382,12 +347,13 @@ class FlatGraspEstimator(Node):
         if len(top_ring) < MIN_POINTS_FOR_PCA:
             top_ring = rim_points
 
-        # --- NEAR RIM POINT (closest to base, along the top ring) ---
+        # --- NEAR RIM POINT (closest to robot, within the top ring) ---
         horiz_dist = np.sqrt(top_ring[:, 0] ** 2 + top_ring[:, 1] ** 2)
-        k = max(MIN_POINTS_FOR_PCA, int(RIM_NEAR_FRACTION * len(horiz_dist)))
-        k = min(k, len(horiz_dist))
-        near_idx = np.argsort(horiz_dist)[:k]
-        rim_point = np.median(top_ring[near_idx], axis=0)
+        k = min(
+            max(MIN_POINTS_FOR_PCA, int(RIM_NEAR_FRACTION * len(horiz_dist))),
+            len(horiz_dist),
+        )
+        rim_point = np.median(top_ring[np.argsort(horiz_dist)[:k]], axis=0)
         rim_x, rim_y, rim_z = (
             float(rim_point[0]),
             float(rim_point[1]),
@@ -401,8 +367,6 @@ class FlatGraspEstimator(Node):
         if radial_norm < 1e-6:
             return
         radial = radial / radial_norm
-
-        # Gripper local Y is the finger-closing axis.
         Y_grasp = radial
         X_grasp = np.cross(Y_grasp, Z_grasp)
         X_grasp = X_grasp / np.linalg.norm(X_grasp)
@@ -411,21 +375,7 @@ class FlatGraspEstimator(Node):
         new_rot_mat = np.column_stack((X_grasp, Y_grasp, Z_grasp))
         new_quat = Rotation.from_matrix(new_rot_mat).as_quat()
 
-        # --- PUBLISH ---
-        grasp_pose = PoseStamped()
-        grasp_pose.header.frame_id = self.target_frame
-        grasp_pose.header.stamp = self.get_clock().now().to_msg()
-
-        grasp_pose.pose.position.x = rim_x
-        grasp_pose.pose.position.y = rim_y
-        grasp_pose.pose.position.z = rim_z
-
-        grasp_pose.pose.orientation.x = new_quat[0]
-        grasp_pose.pose.orientation.y = new_quat[1]
-        grasp_pose.pose.orientation.z = new_quat[2]
-        grasp_pose.pose.orientation.w = new_quat[3]
-
-        self.rim_pose_pub.publish(grasp_pose)
+        self.rim_pose_pub.publish(self._make_grasp_pose(rim_x, rim_y, rim_z, new_quat))
 
 
 def main(args=None):

--- a/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
+++ b/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
@@ -38,6 +38,10 @@ TABLE_HEIGHT_OUTLIER_THRESH = 0.015  # 15mm
 RIM_MIN_HEIGHT = 0.05  # m
 # Fraction of points closest to the base used to estimate the near rim point
 BASKET_NEAR_FRACTION = 0.05
+# Percentile of Z used as the rim-top height (robust to a few high outliers)
+BASKET_TOP_PERCENTILE = 90
+# Vertical band below the rim-top kept as the rim ring (meters)
+RIM_TOP_BAND = 0.03
 
 
 class FlatGraspEstimator(Node):
@@ -377,12 +381,22 @@ class FlatGraspEstimator(Node):
             )
             return
 
-        # --- NEAR RIM POINT (closest to base) ---
-        horiz_dist = np.sqrt(rim_points[:, 0] ** 2 + rim_points[:, 1] ** 2)
+        # --- RIM TOP RING ---
+        # The rim is the TOP edge of the basket. Selecting points purely by horizontal
+        # distance picks the whole near wall (top..floor), whose median Z lands near the
+        # wall middle -> the grasp would descend far below the rim. Anchor to the top:
+        # take the rim-top height as a high Z percentile and keep only the top ring.
+        top_z = np.percentile(rim_points[:, 2], BASKET_TOP_PERCENTILE)
+        top_ring = rim_points[rim_points[:, 2] > top_z - RIM_TOP_BAND]
+        if len(top_ring) < MIN_POINTS_FOR_PCA:
+            top_ring = rim_points
+
+        # --- NEAR RIM POINT (closest to base, along the top ring) ---
+        horiz_dist = np.sqrt(top_ring[:, 0] ** 2 + top_ring[:, 1] ** 2)
         k = max(MIN_POINTS_FOR_PCA, int(BASKET_NEAR_FRACTION * len(horiz_dist)))
         k = min(k, len(horiz_dist))
         near_idx = np.argsort(horiz_dist)[:k]
-        rim_point = np.median(rim_points[near_idx], axis=0)
+        rim_point = np.median(top_ring[near_idx], axis=0)
         rim_x, rim_y, rim_z = (
             float(rim_point[0]),
             float(rim_point[1]),
@@ -423,8 +437,8 @@ class FlatGraspEstimator(Node):
         self.basket_pose_pub.publish(grasp_pose)
         self.get_logger().info(
             f"Basket rim grasp (link_base): X={rim_x:.3f}, Y={rim_y:.3f}, "
-            f"Z={rim_z:.4f} (floor_z={floor_z:.4f}, rim_pts={len(rim_points)}, "
-            f"near_k={k})"
+            f"Z={rim_z:.4f} (floor_z={floor_z:.4f}, top_z={top_z:.4f}, "
+            f"rim_pts={len(rim_points)}, top_ring={len(top_ring)}, near_k={k})"
         )
 
 

--- a/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
+++ b/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
@@ -332,10 +332,7 @@ class FlatGraspEstimator(Node):
         floor_z = np.percentile(points_base[:, 2], 5)
         rim_points = points_base[points_base[:, 2] > floor_z + RIM_MIN_HEIGHT]
         if len(rim_points) < MIN_POINTS_FOR_PCA:
-            self.get_logger().warn(
-                "Not enough rim points above the floor for a rim estimate"
-            )
-            return
+            rim_points = points_base
 
         # --- RIM TOP RING ---
         # The rim is the TOP edge of the object. Anchor to the top:

--- a/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
+++ b/manipulation/packages/perception_3d/scripts/flat_grasp_estimator.py
@@ -55,7 +55,7 @@ class FlatGraspEstimator(Node):
         self.depth_frame_id = "zed_left_camera_optical_frame"
 
         self.target_classes = ["spoon", "fork", "knife"]
-        self.basket_classes = ["laundry_basket", "basket"]
+        self.basket_classes = ["aundry_basket", "basket"]
 
         # Start disabled — only enabled explicitly before a cutlery pick.
         # Saves CPU/network when no manipulation is in progress.

--- a/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
@@ -13,6 +13,7 @@ from frida_constants.manipulation_constants import (
     PICK_MAX_DISTANCE,
     CUTLERY_NAMES,
     POUR_OBJECT_NAMES,
+    BASKET_NAMES,
 )
 from typing import Tuple
 import time
@@ -58,6 +59,12 @@ def is_cutlery(object_name: str) -> bool:
     return object_name.lower() in CUTLERY_NAMES
 
 
+def is_basket(object_name: str) -> bool:
+    if object_name is None:
+        return False
+    return object_name.lower() in BASKET_NAMES
+
+
 def is_pour_object(object_name: str) -> bool:
     """Objects that must be picked upright for pouring."""
     if object_name is None:
@@ -80,11 +87,35 @@ class PickManager:
         self.node.create_subscription(
             PoseStamped, "/manipulation/flat_grasp_pose", self.flat_grasp_callback, 10
         )
+        # Basket rim poses are published by the same estimator node on a separate
+        # topic; reuse the same sample buffer (only one branch is active per pick).
+        self.node.create_subscription(
+            PoseStamped,
+            "/manipulation/basket_grasp_pose",
+            self.flat_grasp_callback,
+            10,
+        )
+
+        self._flat_estimator_enable = self.node.create_client(
+            SetBool, "/flat_grasp_estimator/enable"
+        )
 
     def flat_grasp_callback(self, msg):
         self.latest_flat_grasp = msg
         if self._collecting_samples:
             self._grasp_samples.append(msg)
+
+    def set_flat_estimator(self, enabled: bool):
+        """Enable/disable the (flat/basket) grasp estimator node."""
+        if not self._flat_estimator_enable.wait_for_service(timeout_sec=2.0):
+            self.node.get_logger().warn(
+                "flat_grasp_estimator enable service unavailable"
+            )
+            return
+        request = SetBool.Request()
+        request.data = enabled
+        future = self._flat_estimator_enable.call_async(request)
+        wait_for_future(future, timeout=2)
 
     def execute(
         self, object_name: str, point: PointStamped, pick_params, is_shelf: bool = False
@@ -92,10 +123,16 @@ class PickManager:
         self.node.get_logger().info("Executing Pick Task")
         self.node.get_logger().info("Setting initial joint positions")
 
-        is_flat_object = is_cutlery(object_name)
+        is_basket_object = is_basket(object_name)
+        is_flat_object = is_cutlery(object_name) or is_basket_object
 
         if not pick_params.in_configuration:
-            stare_position = "cutlery_stare" if is_flat_object else "table_stare"
+            if is_basket_object:
+                stare_position = "look_back_stare"
+            elif is_cutlery(object_name):
+                stare_position = "cutlery_stare"
+            else:
+                stare_position = "table_stare"
             send_joint_goal(
                 move_joints_action_client=self.node._move_joints_client,
                 named_position=stare_position,
@@ -107,8 +144,11 @@ class PickManager:
 
         if is_flat_object:
             self.node.get_logger().info(
-                f"Cutlery detected: {object_name}. Waiting for flat_grasp_estimator..."
+                f"Flat object detected: {object_name}. Waiting for grasp estimator..."
             )
+
+            # Enable the estimator so it starts publishing grasp poses.
+            self.set_flat_estimator(True)
 
             # Collect multiple poses and average for stable Z
             self._grasp_samples = []
@@ -124,6 +164,7 @@ class PickManager:
 
             if self.latest_flat_grasp is None:
                 self._collecting_samples = False
+                self.set_flat_estimator(False)
                 self.node.get_logger().error(
                     f"Timeout: flat_grasp_pose not received for {object_name}"
                 )
@@ -145,6 +186,7 @@ class PickManager:
             self.node.get_logger().info(f"Collected {len(samples)} grasp samples")
 
             if len(samples) == 0:
+                self.set_flat_estimator(False)
                 self.node.get_logger().error("No grasp samples collected")
                 return False, None
 
@@ -154,16 +196,20 @@ class PickManager:
             avg_z = np.median([s.pose.position.z for s in samples])
             z_std = np.std([s.pose.position.z for s in samples])
 
+            # Basket: publish the rim Z as-is; pick_server applies BASKET_GRASP_Z_TWEAK.
+            # Cutlery: apply the table-tuned FLAT_GRASP_Z_TWEAK here.
+            z_tweak = 0.0 if is_basket_object else FLAT_GRASP_Z_TWEAK
+
             self.node.get_logger().info(
                 f"Averaged pose: X={avg_x:.3f}, Y={avg_y:.3f}, "
-                f"Z={avg_z:.4f} (std={z_std:.4f}), +tweak={FLAT_GRASP_Z_TWEAK}"
+                f"Z={avg_z:.4f} (std={z_std:.4f}), +tweak={z_tweak}"
             )
 
             # Use the last sample's orientation (PCA-computed) with averaged position
             grasp_pose = copy.deepcopy(samples[-1])
             grasp_pose.pose.position.x = float(avg_x)
             grasp_pose.pose.position.y = float(avg_y)
-            grasp_pose.pose.position.z = float(avg_z) + FLAT_GRASP_Z_TWEAK
+            grasp_pose.pose.position.z = float(avg_z) + z_tweak
 
             # Do NOT call get_object_cluster — it adds the table as a
             # collision object which makes MoveIt reject all near-table paths
@@ -238,7 +284,10 @@ class PickManager:
         print("Gripper Result:", result)
 
         if is_flat_object:
-            # Send the estimator pose + a 90° rotated alternative
+            # Cutlery: 90° alternative (either short/long axis grip works).
+            # Basket: 180° flip about Z keeps the fingers radial (straddling the
+            # rim) while flipping the approach for IK reachability.
+            alt_angle = 180 if is_basket_object else 90
             grasp_pose_alt = copy.deepcopy(grasp_pose)
             q_orig = R.from_quat(
                 [
@@ -248,7 +297,7 @@ class PickManager:
                     grasp_pose.pose.orientation.w,
                 ]
             )
-            q_rotated = (q_orig * R.from_euler("z", 90, degrees=True)).as_quat()
+            q_rotated = (q_orig * R.from_euler("z", alt_angle, degrees=True)).as_quat()
             grasp_pose_alt.pose.orientation.x = q_rotated[0]
             grasp_pose_alt.pose.orientation.y = q_rotated[1]
             grasp_pose_alt.pose.orientation.z = q_rotated[2]
@@ -264,6 +313,9 @@ class PickManager:
             )
             future = self.node._pick_motion_action_client.send_goal_async(goal_msg)
             future = wait_for_future(future, timeout=30)
+
+            # Estimator no longer needed once the goal is sent — free it.
+            self.set_flat_estimator(False)
 
             if future:
                 pick_result = future.result().get_result().result

--- a/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
@@ -197,7 +197,7 @@ class PickManager:
             z_std = np.std([s.pose.position.z for s in samples])
 
             # Rim: publish the rim Z as-is; pick_server applies RIM_GRASP_Z_TWEAK.
-            # Cutlery: apply the table-tuned FLAT_GRASP_Z_TWEAK here.
+            # Flat: apply the table-tuned FLAT_GRASP_Z_TWEAK here.
             z_tweak = 0.0 if is_rim_object else FLAT_GRASP_Z_TWEAK
 
             self.node.get_logger().info(
@@ -284,9 +284,8 @@ class PickManager:
         print("Gripper Result:", result)
 
         if is_flat_object:
-            # Cutlery: 90° alternative (either short/long axis grip works).
-            # Rim: 180° flip about Z keeps the fingers radial (straddling the
-            # wall) while flipping the approach for IK reachability.
+            # Flat: 90° alternative (either short/long axis grip works).
+            # Rim: 180° flip about Z keeps the fingers radial.
             alt_angle = 180 if is_rim_object else 90
             grasp_pose_alt = copy.deepcopy(grasp_pose)
             q_orig = R.from_quat(
@@ -420,7 +419,6 @@ class PickManager:
 
         if is_rim_object:
             # Hold the position where pick_server left the arm (lifted pre-grasp).
-            # Do NOT return to a stare pose so the object stays grasped in place.
             self.node.get_logger().info(
                 "Rim pick: holding position (skipping return to stare)"
             )

--- a/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
@@ -81,29 +81,32 @@ class PickManager:
         self.latest_flat_grasp = None
         self._collecting_samples = False
         self._grasp_samples = []
+        self._active_topic = None  # "flat" | "rim"
         self.tf_buffer = Buffer()
         self.tf_listener = TransformListener(self.tf_buffer, self.node)
 
         self.node.create_subscription(
-            PoseStamped, "/manipulation/flat_grasp_pose", self.flat_grasp_callback, 10
+            PoseStamped, "/manipulation/flat_grasp_pose", self._flat_cb, 10
         )
-        # Rim poses are published by the same estimator node on a separate
-        # topic; reuse the same sample buffer (only one branch is active per pick).
         self.node.create_subscription(
-            PoseStamped,
-            "/manipulation/rim_grasp_pose",
-            self.flat_grasp_callback,
-            10,
+            PoseStamped, "/manipulation/rim_grasp_pose", self._rim_cb, 10
         )
 
         self._flat_estimator_enable = self.node.create_client(
             SetBool, "/flat_grasp_estimator/enable"
         )
 
-    def flat_grasp_callback(self, msg):
-        self.latest_flat_grasp = msg
-        if self._collecting_samples:
-            self._grasp_samples.append(msg)
+    def _flat_cb(self, msg):
+        if self._active_topic == "flat":
+            self.latest_flat_grasp = msg
+            if self._collecting_samples:
+                self._grasp_samples.append(msg)
+
+    def _rim_cb(self, msg):
+        if self._active_topic == "rim":
+            self.latest_flat_grasp = msg
+            if self._collecting_samples:
+                self._grasp_samples.append(msg)
 
     def set_flat_estimator(self, enabled: bool):
         """Enable/disable the (flat/rim) grasp estimator node."""
@@ -148,6 +151,7 @@ class PickManager:
             )
 
             # Enable the estimator so it starts publishing grasp poses.
+            self._active_topic = "rim" if is_rim_object else "flat"
             self.set_flat_estimator(True)
 
             # Collect multiple poses and average for stable Z
@@ -314,6 +318,7 @@ class PickManager:
             future = wait_for_future(future, timeout=30)
 
             # Estimator no longer needed once the goal is sent — free it.
+            self._active_topic = None
             self.set_flat_estimator(False)
 
             if future:

--- a/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
@@ -418,17 +418,24 @@ class PickManager:
                 velocity=0.3,
             )
 
-        self.node.get_logger().info("Returning to position")
-
-        self.node.clear_octomap()
-        for i in range(5):
-            return_result = send_joint_goal(
-                move_joints_action_client=self.node._move_joints_client,
-                named_position="table_stare",
-                velocity=0.5,
+        if is_basket_object:
+            # Hold the rim where pick_server left the arm (lifted pre-grasp).
+            # Do NOT return to a stare pose so the basket stays grasped in place.
+            self.node.get_logger().info(
+                "Basket pick: holding rim position (skipping return to stare)"
             )
-            if return_result:
-                break
+        else:
+            self.node.get_logger().info("Returning to position")
+
+            self.node.clear_octomap()
+            for i in range(5):
+                return_result = send_joint_goal(
+                    move_joints_action_client=self.node._move_joints_client,
+                    named_position="table_stare",
+                    velocity=0.5,
+                )
+                if return_result:
+                    break
 
         self.node.get_logger().info("Pick Task completed successfully")
         result.success = True

--- a/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
@@ -128,7 +128,7 @@ class PickManager:
 
         if not pick_params.in_configuration:
             if is_rim_object:
-                stare_position = "look_back_stare"
+                stare_position = "look_side_stare"
             elif is_cutlery(object_name):
                 stare_position = "cutlery_stare"
             else:

--- a/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
@@ -13,7 +13,7 @@ from frida_constants.manipulation_constants import (
     PICK_MAX_DISTANCE,
     CUTLERY_NAMES,
     POUR_OBJECT_NAMES,
-    BASKET_NAMES,
+    RIM_NAMES,
 )
 from typing import Tuple
 import time
@@ -59,10 +59,10 @@ def is_cutlery(object_name: str) -> bool:
     return object_name.lower() in CUTLERY_NAMES
 
 
-def is_basket(object_name: str) -> bool:
+def is_rim(object_name: str) -> bool:
     if object_name is None:
         return False
-    return object_name.lower() in BASKET_NAMES
+    return object_name.lower() in RIM_NAMES
 
 
 def is_pour_object(object_name: str) -> bool:
@@ -87,11 +87,11 @@ class PickManager:
         self.node.create_subscription(
             PoseStamped, "/manipulation/flat_grasp_pose", self.flat_grasp_callback, 10
         )
-        # Basket rim poses are published by the same estimator node on a separate
+        # Rim poses are published by the same estimator node on a separate
         # topic; reuse the same sample buffer (only one branch is active per pick).
         self.node.create_subscription(
             PoseStamped,
-            "/manipulation/basket_grasp_pose",
+            "/manipulation/rim_grasp_pose",
             self.flat_grasp_callback,
             10,
         )
@@ -106,7 +106,7 @@ class PickManager:
             self._grasp_samples.append(msg)
 
     def set_flat_estimator(self, enabled: bool):
-        """Enable/disable the (flat/basket) grasp estimator node."""
+        """Enable/disable the (flat/rim) grasp estimator node."""
         if not self._flat_estimator_enable.wait_for_service(timeout_sec=2.0):
             self.node.get_logger().warn(
                 "flat_grasp_estimator enable service unavailable"
@@ -123,11 +123,11 @@ class PickManager:
         self.node.get_logger().info("Executing Pick Task")
         self.node.get_logger().info("Setting initial joint positions")
 
-        is_basket_object = is_basket(object_name)
-        is_flat_object = is_cutlery(object_name) or is_basket_object
+        is_rim_object = is_rim(object_name)
+        is_flat_object = is_cutlery(object_name) or is_rim_object
 
         if not pick_params.in_configuration:
-            if is_basket_object:
+            if is_rim_object:
                 stare_position = "look_back_stare"
             elif is_cutlery(object_name):
                 stare_position = "cutlery_stare"
@@ -196,9 +196,9 @@ class PickManager:
             avg_z = np.median([s.pose.position.z for s in samples])
             z_std = np.std([s.pose.position.z for s in samples])
 
-            # Basket: publish the rim Z as-is; pick_server applies BASKET_GRASP_Z_TWEAK.
+            # Rim: publish the rim Z as-is; pick_server applies RIM_GRASP_Z_TWEAK.
             # Cutlery: apply the table-tuned FLAT_GRASP_Z_TWEAK here.
-            z_tweak = 0.0 if is_basket_object else FLAT_GRASP_Z_TWEAK
+            z_tweak = 0.0 if is_rim_object else FLAT_GRASP_Z_TWEAK
 
             self.node.get_logger().info(
                 f"Averaged pose: X={avg_x:.3f}, Y={avg_y:.3f}, "
@@ -285,9 +285,9 @@ class PickManager:
 
         if is_flat_object:
             # Cutlery: 90° alternative (either short/long axis grip works).
-            # Basket: 180° flip about Z keeps the fingers radial (straddling the
-            # rim) while flipping the approach for IK reachability.
-            alt_angle = 180 if is_basket_object else 90
+            # Rim: 180° flip about Z keeps the fingers radial (straddling the
+            # wall) while flipping the approach for IK reachability.
+            alt_angle = 180 if is_rim_object else 90
             grasp_pose_alt = copy.deepcopy(grasp_pose)
             q_orig = R.from_quat(
                 [
@@ -418,11 +418,11 @@ class PickManager:
                 velocity=0.3,
             )
 
-        if is_basket_object:
-            # Hold the rim where pick_server left the arm (lifted pre-grasp).
-            # Do NOT return to a stare pose so the basket stays grasped in place.
+        if is_rim_object:
+            # Hold the position where pick_server left the arm (lifted pre-grasp).
+            # Do NOT return to a stare pose so the object stays grasped in place.
             self.node.get_logger().info(
-                "Basket pick: holding rim position (skipping return to stare)"
+                "Rim pick: holding position (skipping return to stare)"
             )
         else:
             self.node.get_logger().info("Returning to position")

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -89,6 +89,10 @@ class PickMotionServer(Node):
         self.ee_tip_offset = self.get_parameter("ee_tip_offset").value
         self.get_logger().info(f"End-effector tip offset: {self.ee_tip_offset} m")
 
+        self.declare_parameter("rim_tip_offset", -0.12)
+        self.rim_tip_offset = self.get_parameter("rim_tip_offset").value
+        self.get_logger().info(f"Rim tip offset: {self.rim_tip_offset} m")
+
         self.get_logger().info(f"Pick Velocity: {PICK_VELOCITY} m/s")
 
         self.tf_buffer = tf2_ros.Buffer()
@@ -305,7 +309,7 @@ class PickMotionServer(Node):
                 # be offset by the full tip distance, not just the link distance —
                 # otherwise the fingers descend too far. (Cutlery uses the link offset
                 # since its force-guarded descent absorbs any residual offset error.)
-                offset_distance = -0.12 if is_rim else self.ee_link_offset
+                offset_distance = self.rim_tip_offset if is_rim else self.ee_link_offset
                 offset_distance += j * grasping_alternative_distance
 
                 quat = [

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -305,10 +305,7 @@ class PickMotionServer(Node):
                 if self._estop:
                     return False, pick_result
                 ee_link_pose = copy.deepcopy(pose)
-                # Rim pick: fingertips straddle the wall, so the commanded frame must
-                # be offset by the full tip distance, not just the link distance —
-                # otherwise the fingers descend too far. (Cutlery uses the link offset
-                # since its force-guarded descent absorbs any residual offset error.)
+                # Rim: offset by full tip distance so fingers straddle the wall without descending too far.
                 offset_distance = self.rim_tip_offset if is_rim else self.ee_link_offset
                 offset_distance += j * grasping_alternative_distance
 
@@ -453,7 +450,7 @@ class PickMotionServer(Node):
                         self._clear_octomap_client.call_async(req)
                     time.sleep(0.3)
 
-                    # Fixed-distance descent (xArm cartesian velocity, no MoveIt, no force)
+                    # Fixed-distance descent (xArm cartesian velocity)
                     self.get_logger().info(
                         f"[Rim] Descending a fixed {RIM_DESCENT_DISTANCE * 1000:.0f}mm..."
                     )
@@ -660,8 +657,6 @@ class PickMotionServer(Node):
     def fixed_distance_descent(self, distance_m: float) -> bool:
         """
         Descend a FIXED distance in -Z using xArm mode 5 (cartesian velocity control).
-        Open-loop: no effort monitoring. The descent runs for distance/speed seconds
-        then stops. Reuses the same mode-switching machinery as force_guarded_descent.
         """
         self.get_logger().info(
             f"[FixedDescent] Descending {distance_m * 1000:.0f}mm at "

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -463,7 +463,7 @@ class PickMotionServer(Node):
 
                     self.get_logger().info("[Rim] Pre-grasp reached")
 
-                    # Clear octomap before the open-loop descent
+                    # Clear octomap
                     self.get_logger().info("[Rim] Clearing octomap...")
                     if self._clear_octomap_client.wait_for_service(timeout_sec=1.0):
                         req = Empty.Request()

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -306,9 +306,7 @@ class PickMotionServer(Node):
                 # the link distance — otherwise the fingers descend too far and hit
                 # the basket. (Cutlery uses the link offset since its force-guarded
                 # descent absorbs any residual offset error.)
-                offset_distance = (
-                    self.ee_tip_offset if is_basket else self.ee_link_offset
-                )
+                offset_distance = -0.12 if is_basket else self.ee_link_offset
                 offset_distance += j * grasping_alternative_distance
 
                 quat = [
@@ -469,15 +467,6 @@ class PickMotionServer(Node):
                     close_gripper(self._gripper_set_state_client)
                     time.sleep(1.5)
                     self.get_logger().info("[Basket] Gripper closed")
-
-                    # Lift back to pre-grasp (MoveIt)
-                    self.get_logger().info("[Basket] Lifting...")
-                    self.move_to_pose(pre_grasp_pose, velocity=0.2)
-
-                    pick_result.pick_pose = ee_link_pose
-                    pick_result.grasp_score = goal_handle.request.grasping_scores[i]
-                    pick_result.object_pick_height = 0.0
-                    pick_result.object_height = 0.0
 
                     self.get_logger().info("[Basket] Pick complete!")
                     return True, pick_result

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -192,6 +192,12 @@ class PickMotionServer(Node):
             return None
         return self._latest_robot_state.pose[2] / 1000.0
 
+    def _clear_octomap(self, settle: float = 0.3):
+        """Clear the octomap and wait briefly for the planning scene to update."""
+        if self._clear_octomap_client.wait_for_service(timeout_sec=1.0):
+            self._clear_octomap_client.call_async(Empty.Request())
+        time.sleep(settle)
+
     async def execute_callback(self, goal_handle):
         self.get_logger().info("Executing pick goal...")
 
@@ -372,6 +378,8 @@ class PickMotionServer(Node):
                         f"(target Z={ee_link_pose.pose.position.z:.4f})"
                     )
 
+                    self._clear_octomap()
+
                     pre_handler, pre_result = self.move_to_pose(
                         pre_grasp_pose, velocity=0.3
                     )
@@ -386,10 +394,7 @@ class PickMotionServer(Node):
 
                     # Clear octomap
                     self.get_logger().info("[Cutlery] Clearing octomap...")
-                    if self._clear_octomap_client.wait_for_service(timeout_sec=1.0):
-                        req = Empty.Request()
-                        self._clear_octomap_client.call_async(req)
-                    time.sleep(0.3)
+                    self._clear_octomap()
 
                     # Force-guarded descent
                     self.get_logger().info(
@@ -451,6 +456,8 @@ class PickMotionServer(Node):
                         f"(rim Z={ee_link_pose.pose.position.z:.4f})"
                     )
 
+                    self._clear_octomap()
+
                     pre_handler, pre_result = self.move_to_pose(
                         pre_grasp_pose, velocity=0.3
                     )
@@ -463,12 +470,9 @@ class PickMotionServer(Node):
 
                     self.get_logger().info("[Rim] Pre-grasp reached")
 
-                    # Clear octomap
+                    # Clear octomap again before the descent phase.
                     self.get_logger().info("[Rim] Clearing octomap...")
-                    if self._clear_octomap_client.wait_for_service(timeout_sec=1.0):
-                        req = Empty.Request()
-                        self._clear_octomap_client.call_async(req)
-                    time.sleep(0.3)
+                    self._clear_octomap()
 
                     # Fixed-distance descent (xArm cartesian velocity)
                     self.get_logger().info(

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -301,7 +301,14 @@ class PickMotionServer(Node):
                 if self._estop:
                     return False, pick_result
                 ee_link_pose = copy.deepcopy(pose)
-                offset_distance = self.ee_link_offset
+                # Basket is grasped with the fingertips straddling the rim, so the
+                # commanded frame must be offset by the full tip distance, not just
+                # the link distance — otherwise the fingers descend too far and hit
+                # the basket. (Cutlery uses the link offset since its force-guarded
+                # descent absorbs any residual offset error.)
+                offset_distance = (
+                    self.ee_tip_offset if is_basket else self.ee_link_offset
+                )
                 offset_distance += j * grasping_alternative_distance
 
                 quat = [

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -23,6 +23,10 @@ from frida_constants.manipulation_constants import (
     GRIPPER_SET_STATE_SERVICE,
     GO_TO_HAND_ACTION_SERVER,
     ESTOP_TOPIC,
+    BASKET_NAMES,
+    BASKET_PRE_GRASP_HEIGHT,
+    BASKET_DESCENT_SPEED,
+    BASKET_DESCENT_DISTANCE,
 )
 from frida_interfaces.srv import (
     AttachCollisionObject,
@@ -274,10 +278,16 @@ class PickMotionServer(Node):
         grasping_poses = goal_handle.request.grasping_poses
 
         is_flat = goal_handle.request.object_name.lower() in CUTLERY_NAMES
+        is_basket = goal_handle.request.object_name.lower() in BASKET_NAMES
 
         if is_flat:
             num_grasping_alternatives = 6
             grasping_alternative_distance = -0.005
+        elif is_basket:
+            # Each grasping_pose is already a distinct radial/flip candidate;
+            # no extra z-offset alternatives needed.
+            num_grasping_alternatives = 1
+            grasping_alternative_distance = 0.0
         else:
             num_grasping_alternatives = 2
             grasping_alternative_distance = -0.025
@@ -395,6 +405,75 @@ class PickMotionServer(Node):
                             f"[Cutlery] No contact for alternative {j}, trying next"
                         )
                         continue
+
+                elif is_basket:
+                    self.get_logger().info(
+                        f"[Basket] Fixed-distance pick flow for pose {i}"
+                    )
+
+                    # Open gripper
+                    self.get_logger().info("[Basket] Opening gripper...")
+                    self._gripper_set_state_client.wait_for_service(timeout_sec=2.0)
+                    open_gripper(self._gripper_set_state_client)
+                    time.sleep(0.5)
+
+                    # Pre-grasp above the rim (MoveIt)
+                    pre_grasp_pose = copy.deepcopy(ee_link_pose)
+                    pre_grasp_pose.pose.position.z += BASKET_PRE_GRASP_HEIGHT
+
+                    self.get_logger().info(
+                        f"[Basket] Pre-grasp Z={pre_grasp_pose.pose.position.z:.4f} "
+                        f"(rim Z={ee_link_pose.pose.position.z:.4f})"
+                    )
+
+                    pre_handler, pre_result = self.move_to_pose(
+                        pre_grasp_pose, velocity=0.3
+                    )
+
+                    if not pre_result.result.success:
+                        self.get_logger().warn(
+                            f"[Basket] Pre-grasp failed for pose {i}, trying next"
+                        )
+                        continue
+
+                    self.get_logger().info("[Basket] Pre-grasp reached")
+
+                    # Clear octomap before the open-loop descent
+                    self.get_logger().info("[Basket] Clearing octomap...")
+                    if self._clear_octomap_client.wait_for_service(timeout_sec=1.0):
+                        req = Empty.Request()
+                        self._clear_octomap_client.call_async(req)
+                    time.sleep(0.3)
+
+                    # Fixed-distance descent (xArm cartesian velocity, no MoveIt, no force)
+                    self.get_logger().info(
+                        f"[Basket] Descending a fixed {BASKET_DESCENT_DISTANCE * 1000:.0f}mm..."
+                    )
+                    descended = self.fixed_distance_descent(BASKET_DESCENT_DISTANCE)
+
+                    if not descended:
+                        self.get_logger().warn(
+                            f"[Basket] Descent failed for pose {i}, trying next"
+                        )
+                        continue
+
+                    # Close gripper on the rim
+                    self.get_logger().info("[Basket] Closing gripper...")
+                    close_gripper(self._gripper_set_state_client)
+                    time.sleep(1.5)
+                    self.get_logger().info("[Basket] Gripper closed")
+
+                    # Lift back to pre-grasp (MoveIt)
+                    self.get_logger().info("[Basket] Lifting...")
+                    self.move_to_pose(pre_grasp_pose, velocity=0.2)
+
+                    pick_result.pick_pose = ee_link_pose
+                    pick_result.grasp_score = goal_handle.request.grasping_scores[i]
+                    pick_result.object_pick_height = 0.0
+                    pick_result.object_height = 0.0
+
+                    self.get_logger().info("[Basket] Pick complete!")
+                    return True, pick_result
 
                 else:
                     grasp_pose_handler, grasp_pose_result = self.move_to_pose(
@@ -578,6 +657,81 @@ class PickMotionServer(Node):
         self._restore_mode1()
 
         return contact_detected
+
+    def fixed_distance_descent(self, distance_m: float) -> bool:
+        """
+        Descend a FIXED distance in -Z using xArm mode 5 (cartesian velocity control).
+        Open-loop: no effort monitoring. The descent runs for distance/speed seconds
+        then stops. Reuses the same mode-switching machinery as force_guarded_descent.
+        """
+        self.get_logger().info(
+            f"[FixedDescent] Descending {distance_m * 1000:.0f}mm at "
+            f"{BASKET_DESCENT_SPEED:.1f} mm/s"
+        )
+
+        # --- Transition: mode 1 -> 0 -> 5 ---
+        if not self._set_xarm_mode(0):
+            self.get_logger().error("[FixedDescent] Failed to set mode 0")
+            return False
+        time.sleep(0.5)
+
+        if not self._set_xarm_mode(5):
+            self.get_logger().error("[FixedDescent] Failed to set mode 5")
+            self._restore_mode1()
+            return False
+
+        self.get_logger().info(
+            f"[FixedDescent] Waiting {MODE_SWITCH_SETTLE_TIME}s for mode 5 settle..."
+        )
+        time.sleep(MODE_SWITCH_SETTLE_TIME)
+
+        success = False
+        try:
+            if not self._vc_set_cartesian_velocity_client.wait_for_service(
+                timeout_sec=2.0
+            ):
+                self.get_logger().error(
+                    "[FixedDescent] vc_set_cartesian_velocity not available"
+                )
+                self._restore_mode1()
+                return False
+
+            vel_req = MoveVelocity.Request()
+            vel_req.speeds = [0.0, 0.0, -BASKET_DESCENT_SPEED, 0.0, 0.0, 0.0]
+            vel_req.is_tool_coord = False
+            vel_req.duration = 0.0
+
+            vel_future = self._vc_set_cartesian_velocity_client.call_async(vel_req)
+            self.wait_for_future(vel_future)
+
+            if vel_future.result() is None:
+                self.get_logger().error("[FixedDescent] Velocity command failed")
+                self._restore_mode1()
+                return False
+
+            # Open-loop: hold velocity for the time needed to cover the distance.
+            descent_time = (distance_m * 1000.0) / BASKET_DESCENT_SPEED
+            self.get_logger().info(
+                f"[FixedDescent] Holding velocity for {descent_time:.2f}s"
+            )
+            elapsed = 0.0
+            while elapsed < descent_time:
+                if self._estop:
+                    self.get_logger().warn("[FixedDescent] E-stop during descent")
+                    break
+                time.sleep(0.02)
+                elapsed += 0.02
+
+            success = not self._estop
+
+        except Exception as e:
+            self.get_logger().error(f"[FixedDescent] Descent error: {e}")
+
+        # --- Stop and restore mode 1 ---
+        self._stop_cartesian_velocity()
+        self._restore_mode1()
+
+        return success
 
     def _set_xarm_mode(self, mode: int) -> bool:
         try:

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -23,10 +23,10 @@ from frida_constants.manipulation_constants import (
     GRIPPER_SET_STATE_SERVICE,
     GO_TO_HAND_ACTION_SERVER,
     ESTOP_TOPIC,
-    BASKET_NAMES,
-    BASKET_PRE_GRASP_HEIGHT,
-    BASKET_DESCENT_SPEED,
-    BASKET_DESCENT_DISTANCE,
+    RIM_NAMES,
+    RIM_PRE_GRASP_HEIGHT,
+    RIM_DESCENT_SPEED,
+    RIM_DESCENT_DISTANCE,
 )
 from frida_interfaces.srv import (
     AttachCollisionObject,
@@ -278,12 +278,12 @@ class PickMotionServer(Node):
         grasping_poses = goal_handle.request.grasping_poses
 
         is_flat = goal_handle.request.object_name.lower() in CUTLERY_NAMES
-        is_basket = goal_handle.request.object_name.lower() in BASKET_NAMES
+        is_rim = goal_handle.request.object_name.lower() in RIM_NAMES
 
         if is_flat:
             num_grasping_alternatives = 6
             grasping_alternative_distance = -0.005
-        elif is_basket:
+        elif is_rim:
             # Each grasping_pose is already a distinct radial/flip candidate;
             # no extra z-offset alternatives needed.
             num_grasping_alternatives = 1
@@ -301,12 +301,11 @@ class PickMotionServer(Node):
                 if self._estop:
                     return False, pick_result
                 ee_link_pose = copy.deepcopy(pose)
-                # Basket is grasped with the fingertips straddling the rim, so the
-                # commanded frame must be offset by the full tip distance, not just
-                # the link distance — otherwise the fingers descend too far and hit
-                # the basket. (Cutlery uses the link offset since its force-guarded
-                # descent absorbs any residual offset error.)
-                offset_distance = -0.12 if is_basket else self.ee_link_offset
+                # Rim pick: fingertips straddle the wall, so the commanded frame must
+                # be offset by the full tip distance, not just the link distance —
+                # otherwise the fingers descend too far. (Cutlery uses the link offset
+                # since its force-guarded descent absorbs any residual offset error.)
+                offset_distance = -0.12 if is_rim else self.ee_link_offset
                 offset_distance += j * grasping_alternative_distance
 
                 quat = [
@@ -411,23 +410,23 @@ class PickMotionServer(Node):
                         )
                         continue
 
-                elif is_basket:
+                elif is_rim:
                     self.get_logger().info(
-                        f"[Basket] Fixed-distance pick flow for pose {i}"
+                        f"[Rim] Fixed-distance pick flow for pose {i}"
                     )
 
                     # Open gripper
-                    self.get_logger().info("[Basket] Opening gripper...")
+                    self.get_logger().info("[Rim] Opening gripper...")
                     self._gripper_set_state_client.wait_for_service(timeout_sec=2.0)
                     open_gripper(self._gripper_set_state_client)
                     time.sleep(0.5)
 
                     # Pre-grasp above the rim (MoveIt)
                     pre_grasp_pose = copy.deepcopy(ee_link_pose)
-                    pre_grasp_pose.pose.position.z += BASKET_PRE_GRASP_HEIGHT
+                    pre_grasp_pose.pose.position.z += RIM_PRE_GRASP_HEIGHT
 
                     self.get_logger().info(
-                        f"[Basket] Pre-grasp Z={pre_grasp_pose.pose.position.z:.4f} "
+                        f"[Rim] Pre-grasp Z={pre_grasp_pose.pose.position.z:.4f} "
                         f"(rim Z={ee_link_pose.pose.position.z:.4f})"
                     )
 
@@ -437,14 +436,14 @@ class PickMotionServer(Node):
 
                     if not pre_result.result.success:
                         self.get_logger().warn(
-                            f"[Basket] Pre-grasp failed for pose {i}, trying next"
+                            f"[Rim] Pre-grasp failed for pose {i}, trying next"
                         )
                         continue
 
-                    self.get_logger().info("[Basket] Pre-grasp reached")
+                    self.get_logger().info("[Rim] Pre-grasp reached")
 
                     # Clear octomap before the open-loop descent
-                    self.get_logger().info("[Basket] Clearing octomap...")
+                    self.get_logger().info("[Rim] Clearing octomap...")
                     if self._clear_octomap_client.wait_for_service(timeout_sec=1.0):
                         req = Empty.Request()
                         self._clear_octomap_client.call_async(req)
@@ -452,23 +451,23 @@ class PickMotionServer(Node):
 
                     # Fixed-distance descent (xArm cartesian velocity, no MoveIt, no force)
                     self.get_logger().info(
-                        f"[Basket] Descending a fixed {BASKET_DESCENT_DISTANCE * 1000:.0f}mm..."
+                        f"[Rim] Descending a fixed {RIM_DESCENT_DISTANCE * 1000:.0f}mm..."
                     )
-                    descended = self.fixed_distance_descent(BASKET_DESCENT_DISTANCE)
+                    descended = self.fixed_distance_descent(RIM_DESCENT_DISTANCE)
 
                     if not descended:
                         self.get_logger().warn(
-                            f"[Basket] Descent failed for pose {i}, trying next"
+                            f"[Rim] Descent failed for pose {i}, trying next"
                         )
                         continue
 
                     # Close gripper on the rim
-                    self.get_logger().info("[Basket] Closing gripper...")
+                    self.get_logger().info("[Rim] Closing gripper...")
                     close_gripper(self._gripper_set_state_client)
                     time.sleep(1.5)
-                    self.get_logger().info("[Basket] Gripper closed")
+                    self.get_logger().info("[Rim] Gripper closed")
 
-                    self.get_logger().info("[Basket] Pick complete!")
+                    self.get_logger().info("[Rim] Pick complete!")
                     return True, pick_result
 
                 else:
@@ -662,7 +661,7 @@ class PickMotionServer(Node):
         """
         self.get_logger().info(
             f"[FixedDescent] Descending {distance_m * 1000:.0f}mm at "
-            f"{BASKET_DESCENT_SPEED:.1f} mm/s"
+            f"{RIM_DESCENT_SPEED:.1f} mm/s"
         )
 
         # --- Transition: mode 1 -> 0 -> 5 ---
@@ -693,7 +692,7 @@ class PickMotionServer(Node):
                 return False
 
             vel_req = MoveVelocity.Request()
-            vel_req.speeds = [0.0, 0.0, -BASKET_DESCENT_SPEED, 0.0, 0.0, 0.0]
+            vel_req.speeds = [0.0, 0.0, -RIM_DESCENT_SPEED, 0.0, 0.0, 0.0]
             vel_req.is_tool_coord = False
             vel_req.duration = 0.0
 
@@ -706,7 +705,7 @@ class PickMotionServer(Node):
                 return False
 
             # Open-loop: hold velocity for the time needed to cover the distance.
-            descent_time = (distance_m * 1000.0) / BASKET_DESCENT_SPEED
+            descent_time = (distance_m * 1000.0) / RIM_DESCENT_SPEED
             self.get_logger().info(
                 f"[FixedDescent] Holding velocity for {descent_time:.2f}s"
             )

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -27,6 +27,7 @@ from frida_constants.manipulation_constants import (
     RIM_PRE_GRASP_HEIGHT,
     RIM_DESCENT_SPEED,
     RIM_DESCENT_DISTANCE,
+    XARM_ROBOT_STATES_TOPIC,
 )
 from frida_interfaces.srv import (
     AttachCollisionObject,
@@ -54,6 +55,7 @@ from std_srvs.srv import Empty
 # Force-guarded descent imports
 from sensor_msgs.msg import JointState
 from xarm_msgs.srv import MoveVelocity, SetInt16
+from xarm_msgs.msg import RobotMsg
 
 # =============================================================================
 # Force-guarded descent constants
@@ -74,6 +76,9 @@ CUTLERY_POST_CONTACT_RETRACT = 0.002  # m - retract upward after contact to reli
 MODE_SWITCH_SETTLE_TIME = 1.0  # s - wait after entering mode 5
 MODE1_RECOVERY_TIME = 3.0  # s - wait after restoring mode 1 for traj controller
 MODE1_RETRY_ATTEMPTS = 3  # retries for restoring mode 1
+
+# Closed-loop fixed-distance descent constants
+DESCENT_TIMEOUT_FACTOR = 2.5
 
 
 class PickMotionServer(Node):
@@ -158,6 +163,12 @@ class PickMotionServer(Node):
             JointState, "/joint_states", self._joint_state_cb, 10
         )
 
+        # TCP position feedback for closed-loop descent
+        self._latest_robot_state = None
+        self.create_subscription(
+            RobotMsg, XARM_ROBOT_STATES_TOPIC, self._robot_state_cb, 10
+        )
+
         self._estop = False
         self.create_subscription(
             Bool,
@@ -171,6 +182,15 @@ class PickMotionServer(Node):
 
     def _joint_state_cb(self, msg: JointState):
         self._latest_joint_state = msg
+
+    def _robot_state_cb(self, msg: RobotMsg):
+        self._latest_robot_state = msg
+
+    def _get_tcp_z(self):
+        """Return current TCP Z in meters (base frame), or None if no state received yet."""
+        if self._latest_robot_state is None:
+            return None
+        return self._latest_robot_state.pose[2] / 1000.0
 
     async def execute_callback(self, goal_handle):
         self.get_logger().info("Executing pick goal...")
@@ -656,11 +676,25 @@ class PickMotionServer(Node):
 
     def fixed_distance_descent(self, distance_m: float) -> bool:
         """
-        Descend a FIXED distance in -Z using xArm mode 5 (cartesian velocity control).
+        Descend a fixed distance in -Z using xArm mode 5 (cartesian velocity control).
+        Closed-loop on /xarm/robot_states TCP Z.
         """
         self.get_logger().info(
             f"[FixedDescent] Descending {distance_m * 1000:.0f}mm at "
             f"{RIM_DESCENT_SPEED:.1f} mm/s"
+        )
+
+        # --- Read start position before any mode switch ---
+        start_z = self._get_tcp_z()
+        if start_z is None:
+            self.get_logger().error(
+                "[FixedDescent] No robot_states received — cannot verify descent"
+            )
+            return False
+        target_z = start_z - distance_m
+        self.get_logger().info(
+            f"[FixedDescent] start_z={start_z * 1000:.1f}mm  "
+            f"target_z={target_z * 1000:.1f}mm"
         )
 
         # --- Transition: mode 1 -> 0 -> 5 ---
@@ -679,7 +713,7 @@ class PickMotionServer(Node):
         )
         time.sleep(MODE_SWITCH_SETTLE_TIME)
 
-        success = False
+        reached = False
         try:
             if not self._vc_set_cartesian_velocity_client.wait_for_service(
                 timeout_sec=2.0
@@ -687,7 +721,6 @@ class PickMotionServer(Node):
                 self.get_logger().error(
                     "[FixedDescent] vc_set_cartesian_velocity not available"
                 )
-                self._restore_mode1()
                 return False
 
             vel_req = MoveVelocity.Request()
@@ -695,37 +728,61 @@ class PickMotionServer(Node):
             vel_req.is_tool_coord = False
             vel_req.duration = 0.0
 
+            # Initial velocity command
             vel_future = self._vc_set_cartesian_velocity_client.call_async(vel_req)
             self.wait_for_future(vel_future)
-
             if vel_future.result() is None:
-                self.get_logger().error("[FixedDescent] Velocity command failed")
-                self._restore_mode1()
+                self.get_logger().error(
+                    "[FixedDescent] Initial velocity command failed"
+                )
                 return False
 
-            # Open-loop: hold velocity for the time needed to cover the distance.
-            descent_time = (distance_m * 1000.0) / RIM_DESCENT_SPEED
-            self.get_logger().info(
-                f"[FixedDescent] Holding velocity for {descent_time:.2f}s"
-            )
-            elapsed = 0.0
-            while elapsed < descent_time:
+            expected_time = (distance_m * 1000.0) / RIM_DESCENT_SPEED
+            timeout = expected_time * DESCENT_TIMEOUT_FACTOR
+
+            loop_start = time.time()
+
+            while True:
+                time.sleep(0.02)  # 50 Hz
+                now = time.time()
+                elapsed = now - loop_start
+
+                # Timeout guard
+                if elapsed > timeout:
+                    self.get_logger().warn(
+                        f"[FixedDescent] Timeout after {elapsed:.1f}s "
+                        f"(limit={timeout:.1f}s)"
+                    )
+                    break
+
+                # E-stop
                 if self._estop:
                     self.get_logger().warn("[FixedDescent] E-stop during descent")
                     break
-                time.sleep(0.02)
-                elapsed += 0.02
 
-            success = not self._estop
+                cur_z = self._get_tcp_z()
+                if cur_z is None:
+                    continue
+
+                descended = start_z - cur_z
+
+                # Reached target?
+                if descended >= distance_m:
+                    self.get_logger().info(
+                        f"[FixedDescent] Reached! descended={descended * 1000:.1f}mm "
+                        f"(target={distance_m * 1000:.0f}mm)"
+                    )
+                    reached = True
+                    break
 
         except Exception as e:
             self.get_logger().error(f"[FixedDescent] Descent error: {e}")
 
-        # --- Stop and restore mode 1 ---
-        self._stop_cartesian_velocity()
-        self._restore_mode1()
+        finally:
+            self._stop_cartesian_velocity()
+            self._restore_mode1()
 
-        return success
+        return reached
 
     def _set_xarm_mode(self, mode: int) -> bool:
         try:

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -685,12 +685,15 @@ class PickMotionServer(Node):
         )
 
         # --- Read start position before any mode switch ---
+        wait_start = time.time()
+        while self._get_tcp_z() is None:
+            if time.time() - wait_start > 2.0:
+                self.get_logger().error(
+                    "[FixedDescent] No robot_states received after 2s — cannot verify descent"
+                )
+                return False
+            time.sleep(0.05)
         start_z = self._get_tcp_z()
-        if start_z is None:
-            self.get_logger().error(
-                "[FixedDescent] No robot_states received — cannot verify descent"
-            )
-            return False
         target_z = start_z - distance_m
         self.get_logger().info(
             f"[FixedDescent] start_z={start_z * 1000:.1f}mm  "

--- a/task_manager/scripts/test/test_basket_pick.py
+++ b/task_manager/scripts/test/test_basket_pick.py
@@ -3,7 +3,7 @@
 """Manual test for the rim pick feature.
 
 Drives the full pipeline end-to-end through the manipulation action server:
-  look_back_stare -> enable grasp estimator -> detect "laundry_basket" ->
+  look_side_stare -> enable grasp estimator -> detect "laundry_basket" ->
   rim_grasp_estimator publishes the near-rim pose -> PickManager builds a
   PickMotion goal -> pick_server does MoveIt pre-grasp + fixed-distance descent
   -> close gripper -> lift.
@@ -12,7 +12,7 @@ Requirements before running:
   - manipulation stack up (manipulation_core / pick_server) and the
     flat_grasp_estimator node (it also handles rim objects).
   - vision detector publishing on /vision/detections with a "laundry_basket"
-    class, and an object on the floor within view of look_back_stare.
+    class, and an object on the floor within view of look_side_stare.
 
 PickManager enables/disables the estimator on its own, so this test only needs
 to send the pick request — same as a normal pick_object call.

--- a/task_manager/scripts/test/test_basket_pick.py
+++ b/task_manager/scripts/test/test_basket_pick.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 
-"""Manual test for the laundry-basket rim pick feature.
+"""Manual test for the rim pick feature.
 
 Drives the full pipeline end-to-end through the manipulation action server:
   look_back_stare -> enable grasp estimator -> detect "laundry_basket" ->
-  basket_grasp_estimator publishes the near-rim pose -> PickManager builds a
+  rim_grasp_estimator publishes the near-rim pose -> PickManager builds a
   PickMotion goal -> pick_server does MoveIt pre-grasp + fixed-distance descent
   -> close gripper -> lift.
 
 Requirements before running:
   - manipulation stack up (manipulation_core / pick_server) and the
-    flat_grasp_estimator node (it now also handles baskets).
+    flat_grasp_estimator node (it also handles rim objects).
   - vision detector publishing on /vision/detections with a "laundry_basket"
-    class, and a basket on the floor within view of look_back_stare.
+    class, and an object on the floor within view of look_back_stare.
 
 PickManager enables/disables the estimator on its own, so this test only needs
 to send the pick request — same as a normal pick_object call.
@@ -24,35 +24,35 @@ from task_manager.utils.status import Status
 from task_manager.utils.task import Task
 from task_manager.subtask_managers.manipulation_tasks import ManipulationTasks
 
-# Must match an entry in BASKET_NAMES (frida_constants.manipulation_constants)
-# and the label the detector publishes for the basket.
+# Must match an entry in RIM_NAMES (frida_constants.manipulation_constants)
+# and the label the detector publishes for the object.
 OBJECT_NAME = "aundry_basket"
 
 
-class TestBasketPick(Node):
+class TestRimPick(Node):
     def __init__(self):
-        super().__init__("test_basket_pick")
+        super().__init__("test_rim_pick")
 
         self.manipulation_manager = ManipulationTasks(self, task=Task.DEBUG, mock_data=False)
 
         rclpy.spin_once(self, timeout_sec=1.0)
-        self.get_logger().info("Test Basket Pick started.")
+        self.get_logger().info("Test Rim Pick started.")
         self.run()
 
     def run(self):
-        self.get_logger().info(f"--- STARTING BASKET PICK TEST ({OBJECT_NAME}) ---")
+        self.get_logger().info(f"--- STARTING RIM PICK TEST ({OBJECT_NAME}) ---")
 
         result = self.manipulation_manager.pick_object(OBJECT_NAME)
 
         if result == Status.EXECUTION_SUCCESS:
-            self.get_logger().info("SUCCESS: Basket rim picked.")
+            self.get_logger().info("SUCCESS: Rim pick succeeded.")
         else:
             self.get_logger().error(f"FAILED: Result status {result}")
 
 
 def main(args=None):
     rclpy.init(args=args)
-    node = TestBasketPick()
+    node = TestRimPick()
     try:
         rclpy.spin(node)
     except KeyboardInterrupt:

--- a/task_manager/scripts/test/test_basket_pick.py
+++ b/task_manager/scripts/test/test_basket_pick.py
@@ -26,7 +26,7 @@ from task_manager.subtask_managers.manipulation_tasks import ManipulationTasks
 
 # Must match an entry in BASKET_NAMES (frida_constants.manipulation_constants)
 # and the label the detector publishes for the basket.
-OBJECT_NAME = "laundry_basket"
+OBJECT_NAME = "aundry_basket"
 
 
 class TestBasketPick(Node):

--- a/task_manager/scripts/test/test_basket_pick.py
+++ b/task_manager/scripts/test/test_basket_pick.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+"""Manual test for the laundry-basket rim pick feature.
+
+Drives the full pipeline end-to-end through the manipulation action server:
+  look_back_stare -> enable grasp estimator -> detect "laundry_basket" ->
+  basket_grasp_estimator publishes the near-rim pose -> PickManager builds a
+  PickMotion goal -> pick_server does MoveIt pre-grasp + fixed-distance descent
+  -> close gripper -> lift.
+
+Requirements before running:
+  - manipulation stack up (manipulation_core / pick_server) and the
+    flat_grasp_estimator node (it now also handles baskets).
+  - vision detector publishing on /vision/detections with a "laundry_basket"
+    class, and a basket on the floor within view of look_back_stare.
+
+PickManager enables/disables the estimator on its own, so this test only needs
+to send the pick request — same as a normal pick_object call.
+"""
+
+import rclpy
+from rclpy.node import Node
+from task_manager.utils.status import Status
+from task_manager.utils.task import Task
+from task_manager.subtask_managers.manipulation_tasks import ManipulationTasks
+
+# Must match an entry in BASKET_NAMES (frida_constants.manipulation_constants)
+# and the label the detector publishes for the basket.
+OBJECT_NAME = "laundry_basket"
+
+
+class TestBasketPick(Node):
+    def __init__(self):
+        super().__init__("test_basket_pick")
+
+        self.manipulation_manager = ManipulationTasks(self, task=Task.DEBUG, mock_data=False)
+
+        rclpy.spin_once(self, timeout_sec=1.0)
+        self.get_logger().info("Test Basket Pick started.")
+        self.run()
+
+    def run(self):
+        self.get_logger().info(f"--- STARTING BASKET PICK TEST ({OBJECT_NAME}) ---")
+
+        result = self.manipulation_manager.pick_object(OBJECT_NAME)
+
+        if result == Status.EXECUTION_SUCCESS:
+            self.get_logger().info("SUCCESS: Basket rim picked.")
+        else:
+            self.get_logger().error(f"FAILED: Result status {result}")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = TestBasketPick()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Rim pick pipeline: Adds support for picking objects by their top rim edge using a MoveIt pre-grasp + fixed-distance open-loop cartesian descent 
- Rim grasp estimator: flat_grasp_estimator now handles rim objects — deprojects the full bbox frustum, rejects the floor, anchors to the top Z percentile, and publishes a radial straddle grasp pose on /manipulation/rim_grasp_pose.

https://github.com/user-attachments/assets/83fa8567-adfb-439b-9fb8-f268366f058b


https://github.com/user-attachments/assets/e4a6a4f7-a6cf-49f3-b37e-42f13edaae05


