### PR TITLE
Add click dependency

### DIFF
--- a/docker/hri/dockerfiles/Dockerfile.tts
+++ b/docker/hri/dockerfiles/Dockerfile.tts
@@ -38,6 +38,7 @@ COPY hri/requirements/tts.txt requirements.txt
 RUN python3 -m pip install --upgrade pip
 RUN pip install --no-cache-dir -r /app/requirements.txt
 RUN pip install --upgrade protobuf
+RUN pip install --no-cache-dir click
 RUN python3 -m spacy download en_core_web_sm
 
 COPY hri/proto_interfaces /tmp/proto_interfaces


### PR DESCRIPTION
Error building image:
   > [10/12] RUN python3 -m spacy download en_core_web_sm:                                                                                                                                                                                
  1.734     __import__(pkg_name)                                                                                                                                                                                                          
  1.734   File "/opt/venv/lib/python3.10/site-packages/spacy/__init__.py", line 18, in <module>                                                                                                                                           
  1.734     from .cli.info import info  # noqa: F401                                                                                                                                                                                      
  1.734   File "/opt/venv/lib/python3.10/site-packages/spacy/cli/__init__.py", line 4, in <module>                                                                                                                                        
  1.734     from . import download as download_module  # noqa: F401                                                                                                                                                                       
  1.734   File "/opt/venv/lib/python3.10/site-packages/spacy/cli/download.py", line 21, in <module>                                                                                                                                       
  1.734     from ._util import SDIST_SUFFIX, WHEEL_SUFFIX, Arg, Opt, app                                                                                                                                                                  
  1.734   File "/opt/venv/lib/python3.10/site-packages/spacy/cli/_util.py", line 18, in <module>                                                                                                                                          
  1.734     from click import NoSuchOption                                                                                                                                                                                                
  1.734 ModuleNotFoundError: No module named 'click'