### PR TITLE
fix urdf

### DIFF
--- a/navigation/packages/nav_main/launch/omni_setup/omni_basics.launch.py
+++ b/navigation/packages/nav_main/launch/omni_setup/omni_basics.launch.py
@@ -78,11 +78,6 @@ def generate_launch_description():
 
             'map_frame': 'map',
             'odom_frame': 'odom',
-            # base_footprint is the URDF root (see FRIDA_Real.urdf.xacro). The EKF
-            # must drive the root so the TF tree stays connected: map -> odom ->
-            # base_footprint -> base_link -> arm. Driving base_link instead steals
-            # it from the URDF static base_footprint->base_link and splits TF in
-            # two, detaching MoveIt's planning frame (ghost robot / empty octomap).
             'base_link_frame': 'base_footprint',
             'world_frame': 'odom',   # estimate odom -> base_footprint only (no map yet)
 

--- a/navigation/packages/nav_main/launch/omni_setup/omni_basics.launch.py
+++ b/navigation/packages/nav_main/launch/omni_setup/omni_basics.launch.py
@@ -74,12 +74,12 @@ def generate_launch_description():
             'frequency': 30.0,
             'sensor_timeout': 0.2,   # telemetry is ~25-35 Hz; 0.2 s tolerates a few dropped frames
             'two_d_mode': True,      # planar base: zero Z / roll / pitch
-            'publish_tf': True,      # publishes odom -> base_footprint (do NOT also run odom_to_tf.py)
+            'publish_tf': True,      # publishes odom -> base_link (do NOT also run odom_to_tf.py)
 
             'map_frame': 'map',
             'odom_frame': 'odom',
-            'base_link_frame': 'base_footprint',
-            'world_frame': 'odom',   # estimate odom -> base_footprint only (no map yet)
+            'base_link_frame': 'base_link',
+            'world_frame': 'odom',   # estimate odom -> base_link only (no map yet)
 
             # --- Wheel odometry (mecanum): fuse body-frame vx, vy ONLY.
             # vx (index 6) and vy (index 7) are True; everything else False.

--- a/navigation/packages/nav_main/launch/omni_setup/omni_basics.launch.py
+++ b/navigation/packages/nav_main/launch/omni_setup/omni_basics.launch.py
@@ -74,12 +74,17 @@ def generate_launch_description():
             'frequency': 30.0,
             'sensor_timeout': 0.2,   # telemetry is ~25-35 Hz; 0.2 s tolerates a few dropped frames
             'two_d_mode': True,      # planar base: zero Z / roll / pitch
-            'publish_tf': True,      # publishes odom -> base_link (do NOT also run odom_to_tf.py)
+            'publish_tf': True,      # publishes odom -> base_footprint (do NOT also run odom_to_tf.py)
 
             'map_frame': 'map',
             'odom_frame': 'odom',
-            'base_link_frame': 'base_link',
-            'world_frame': 'odom',   # estimate odom -> base_link only (no map yet)
+            # base_footprint is the URDF root (see FRIDA_Real.urdf.xacro). The EKF
+            # must drive the root so the TF tree stays connected: map -> odom ->
+            # base_footprint -> base_link -> arm. Driving base_link instead steals
+            # it from the URDF static base_footprint->base_link and splits TF in
+            # two, detaching MoveIt's planning frame (ghost robot / empty octomap).
+            'base_link_frame': 'base_footprint',
+            'world_frame': 'odom',   # estimate odom -> base_footprint only (no map yet)
 
             # --- Wheel odometry (mecanum): fuse body-frame vx, vy ONLY.
             # vx (index 6) and vy (index 7) are True; everything else False.

--- a/robot_description/frida_description/urdf/omnibase/FRIDA_Real.urdf.xacro
+++ b/robot_description/frida_description/urdf/omnibase/FRIDA_Real.urdf.xacro
@@ -80,29 +80,26 @@
       <reference name="zed_camera_link"><body gravcomp="1"/></reference>
     </mujoco>
   </xacro:if>
-  <!-- The world<->base_link offset matters for MoveIt because "world" is the
-       planning frame: the plane-collision-object added by perception_3d in
-       "base_link" gets stored by MoveIt in "world", and pick_server.check_
-       feasibility compares its z against the grasp pose (in "base_link").
-       Any non-zero offset becomes a silent frame mismatch that fails every
-       pick.  On the real robot the 0.3 m pedestal is the physical mounting;
-       in MuJoCo the arm is attached directly to world and there is no
-       pedestal, so pin world<->base_link at identity for sim only. -->
-  <link name="world" />
+  <!-- Planning-frame / TF-root policy:
+       In MuJoCo there is no localization running, so the arm is pinned to a
+       fixed "world" root at identity and "world" is MoveIt's planning frame.
+       On the REAL robot, "base_footprint" is the URDF root and the EKF
+       (robot_localization) drives odom -> base_footprint dynamically. We must
+       NOT add a static world -> base_footprint here: it would give
+       base_footprint two parents (this static one and the EKF's), which TF
+       cannot represent. The EKF transform wins, the world branch is orphaned,
+       and MoveIt's planning frame ("world") gets detached from the live
+       map/odom tree -> ghost robot, place collisions, empty octomap. So on the
+       real robot base_footprint is both the URDF root and MoveIt's planning
+       frame, and it stays connected to map via the EKF. -->
   <xacro:if value="$(arg mujoco_plugin)">
+    <link name="world" />
     <joint name="world_to_base" type="fixed">
       <parent link="world" />
       <child link="base_footprint" />
       <origin rpy="0 0 0" xyz="0 0 0" />
     </joint>
   </xacro:if>
-  <xacro:unless value="$(arg mujoco_plugin)">
-    <joint name="world_to_base" type="fixed">
-      <parent link="world" />
-      <child link="base_footprint" />
-      <origin rpy="0 0 0" xyz="0 0 0.3" />
-    </joint>
-  </xacro:unless>
   <!-- XARM MACRO -->
   <xacro:include filename="$(find frida_description)/urdf/xarm/xarm_device_macro.xacro" />
     <xacro:xarm_device prefix="$(arg prefix)" hw_ns="$(arg hw_ns)" limited="$(arg limited)" 

--- a/robot_description/frida_description/urdf/omnibase/FRIDA_Real.urdf.xacro
+++ b/robot_description/frida_description/urdf/omnibase/FRIDA_Real.urdf.xacro
@@ -80,18 +80,6 @@
       <reference name="zed_camera_link"><body gravcomp="1"/></reference>
     </mujoco>
   </xacro:if>
-  <!-- Planning-frame / TF-root policy:
-       In MuJoCo there is no localization running, so the arm is pinned to a
-       fixed "world" root at identity and "world" is MoveIt's planning frame.
-       On the REAL robot, "base_footprint" is the URDF root and the EKF
-       (robot_localization) drives odom -> base_footprint dynamically. We must
-       NOT add a static world -> base_footprint here: it would give
-       base_footprint two parents (this static one and the EKF's), which TF
-       cannot represent. The EKF transform wins, the world branch is orphaned,
-       and MoveIt's planning frame ("world") gets detached from the live
-       map/odom tree -> ghost robot, place collisions, empty octomap. So on the
-       real robot base_footprint is both the URDF root and MoveIt's planning
-       frame, and it stays connected to map via the EKF. -->
   <xacro:if value="$(arg mujoco_plugin)">
     <link name="world" />
     <joint name="world_to_base" type="fixed">


### PR DESCRIPTION
Fix real-robot TF tree: drop the static world→base_footprint URDF joint (kept only for MuJoCo) and switch the EKF to publish odom→base_footprint, making   base_footprint the consistent root and fixing the MoveIt frame mismatch that broke picks.
