### PR TITLE
Robust shelf pick: per-level detection and compartment collision avoidance

### DIFF
--- a/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
@@ -28,6 +28,7 @@ from scipy.spatial.transform import Rotation as R
 from sensor_msgs_py import point_cloud2
 import numpy as np
 from pick_and_place.utils.perception_utils import get_object_point
+from pick_and_place.utils.grasp_orientation import is_frontal_grasp
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 
@@ -322,6 +323,29 @@ class PickManager:
                 if len(new_grasp_poses) == 0:
                     self.node.get_logger().error("No grasp poses detected")
                     continue
+
+                # Shelf picks prefer a frontal grasp; a top-down approach hits the
+                # compartment ceiling. Fallback: unfiltered set. Table picks unchanged.
+                if is_shelf:
+                    kept_poses = []
+                    kept_scores = []
+                    for pose, score in zip(new_grasp_poses, new_grasp_scores):
+                        q = pose.pose.orientation
+                        if is_frontal_grasp((q.x, q.y, q.z, q.w)):
+                            kept_poses.append(pose)
+                            kept_scores.append(score)
+                    if kept_poses:
+                        self.node.get_logger().info(
+                            f"Frontal grasp filter kept "
+                            f"{len(kept_poses)}/{len(new_grasp_poses)} for {object_name}"
+                        )
+                        new_grasp_poses = kept_poses
+                        new_grasp_scores = kept_scores
+                    else:
+                        self.node.get_logger().warn(
+                            f"Frontal grasp filter removed all for {object_name}; "
+                            "using unfiltered set"
+                        )
 
                 goal_msg = PickMotion.Goal()
                 goal_msg.grasping_poses = new_grasp_poses

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -75,6 +75,10 @@ CUTLERY_PRE_GRASP_HEIGHT = (
 )
 CUTLERY_EFFORT_GRACE_PERIOD = 0.5  # s - ignore effort readings for this long after velocity starts (transient spike from mode switch)
 CUTLERY_POST_CONTACT_RETRACT = 0.002  # m - retract upward after contact to relieve Z pressure before closing gripper
+SHELF_RETRACT_DIST = 0.15  # m - fallback retract if the approach depth is unknown
+SHELF_RETRACT_MARGIN = 0.05  # m - extra beyond the measured approach depth
+SHELF_RETRACT_MIN = 0.08  # m - clamp
+SHELF_RETRACT_MAX = 0.30  # m - clamp
 
 # Mode switching timing
 MODE_SWITCH_SETTLE_TIME = 1.0  # s - wait after entering mode 5
@@ -574,6 +578,13 @@ class PickMotionServer(Node):
                     return True, pick_result
 
                 else:
+                    # EE XY before reaching in, to size the retract dynamically.
+                    pre_state = self._latest_robot_state
+                    pre_xy = (
+                        (pre_state.pose[0] / 1000.0, pre_state.pose[1] / 1000.0)
+                        if pre_state is not None
+                        else None
+                    )
                     grasp_pose_handler, grasp_pose_result = self.move_to_pose(
                         ee_link_pose
                     )
@@ -590,6 +601,43 @@ class PickMotionServer(Node):
 
                     if result:
                         self.get_logger().info("Object attached")
+                        # Shelf pick (frontal grasp): pull straight out toward the
+                        # robot in XY (Z constant, clears ceiling). Table unchanged.
+                        approach = quat2mat(
+                            [
+                                ee_link_pose.pose.orientation.w,
+                                ee_link_pose.pose.orientation.x,
+                                ee_link_pose.pose.orientation.y,
+                                ee_link_pose.pose.orientation.z,
+                            ]
+                        )[:, 2]
+                        if abs(float(approach[2])) < 0.5:
+                            retract_pose = copy.deepcopy(ee_link_pose)
+                            gx = ee_link_pose.pose.position.x
+                            gy = ee_link_pose.pose.position.y
+                            dist = SHELF_RETRACT_DIST
+                            post_state = self._latest_robot_state
+                            if pre_xy is not None and post_state is not None:
+                                depth = float(
+                                    np.hypot(
+                                        post_state.pose[0] / 1000.0 - pre_xy[0],
+                                        post_state.pose[1] / 1000.0 - pre_xy[1],
+                                    )
+                                )
+                                dist = min(
+                                    max(
+                                        depth + SHELF_RETRACT_MARGIN, SHELF_RETRACT_MIN
+                                    ),
+                                    SHELF_RETRACT_MAX,
+                                )
+                            n = float(np.hypot(gx, gy))
+                            if n > 1e-6:
+                                retract_pose.pose.position.x -= (gx / n) * dist
+                                retract_pose.pose.position.y -= (gy / n) * dist
+                            self.get_logger().info(
+                                f"Shelf retract: pull-out toward robot ({dist:.3f} m)"
+                            )
+                            self.move_to_pose(retract_pose, velocity=0.2)
                         pick_result.pick_pose = ee_link_pose
                         pick_result.grasp_score = goal_handle.request.grasping_scores[i]
 

--- a/manipulation/packages/pick_and_place/pick_and_place/utils/grasp_orientation.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/utils/grasp_orientation.py
@@ -1,0 +1,15 @@
+"""Frontal grasp check for shelf compartment picks (no ROS, unit-testable offline).
+Top-down hits the compartment ceiling; a frontal grasp reaches in and clears it."""
+
+from scipy.spatial.transform import Rotation as R
+
+FRONTAL_GRASP_MAX_VERTICAL = 0.5  # |approach_z|; 0.5 ~ within 60 deg of horizontal
+
+
+def is_frontal_grasp(
+    quat_xyzw, max_vertical: float = FRONTAL_GRASP_MAX_VERTICAL
+) -> bool:
+    """True if the grasp approaches roughly horizontally (front grasp), not top-down."""
+    rot = R.from_quat([quat_xyzw[0], quat_xyzw[1], quat_xyzw[2], quat_xyzw[3]])
+    approach_z = float(rot.apply([0.0, 0.0, 1.0])[2])
+    return abs(approach_z) <= max_vertical

--- a/task_manager/scripts/pickandplace_task_manager.py
+++ b/task_manager/scripts/pickandplace_task_manager.py
@@ -29,6 +29,7 @@ from frida_interfaces.msg import GripperGraspState
 from frida_constants.manipulation_constants import GRIPPER_GRASP_STATE_TOPIC
 from task_manager.utils.colored_logger import CLog
 from task_manager.utils.status import Status
+from task_manager.utils.shelf_pick_logic import find_target_on_level
 from task_manager.utils.subtask_manager import SubtaskManager, Task
 
 ATTEMPT_LIMIT = 2
@@ -372,6 +373,38 @@ class PickAndPlaceTM(Node):
             height, tolerance=0.1, table_or_shelf=False, approach_plane=True
         )
         self.timeout(3.0)
+
+    def _pick_from_shelf(self, object_name: str, level_heights: dict) -> int:
+        """Detect the target at each shelf level and pick from the level that frames it.
+        table_stare frames only the lower levels, so high-shelf objects were missed."""
+        found_level = None
+        for height in sorted(level_heights.values()):
+            self.subtask_manager.manipulation.get_optimal_position_for_plane(
+                height, tolerance=0.1, table_or_shelf=False, approach_plane=True
+            )
+            self.timeout(3.0)  # let the octomap settle at this level
+            status, detections = self.subtask_manager.vision.detect_objects()
+            retry = 0
+            while status != Status.EXECUTION_SUCCESS and retry < 3:
+                self.timeout(1.0)
+                status, detections = self.subtask_manager.vision.detect_objects()
+                retry += 1
+            if status != Status.EXECUTION_SUCCESS or not detections:
+                continue
+            candidates = [(det.classname, self.convert_to_height(det)) for det in detections]
+            if find_target_on_level(candidates, object_name, height) is not None:
+                CLog.manip(self, "PICK", f"Found {object_name} at shelf height {height:.3f}.")
+                found_level = height
+                break
+
+        if found_level is None:
+            CLog.manip(self, "PICK", f"{object_name} not found on any shelf level.", level="error")
+            return Status.EXECUTION_ERROR
+
+        # Arm is at the found level's pose with a fresh octomap; keep it (in_configuration).
+        return self.subtask_manager.manipulation.pick_object(
+            object_name, in_configuration=True, scan_environment=True
+        )
 
     def categorize_object(self, obj_name: str) -> ObjectCategory:
         """Assign an object to a category based on its name"""
@@ -1052,27 +1085,19 @@ class PickAndPlaceTM(Node):
             item_location = self.current_breakfast_item["location"]
 
             is_cabinet = item_location == Location.CABINET
-            if is_cabinet:
-                if not self._cabinet_scan_fresh:
-                    CLog.manip(self, "PICK", "Scanning shelves for octomap before cabinet pick.")
-                    shelf_levels = sorted(self.shelf_level_heights.keys())
-                    for level in shelf_levels:
-                        self._scan_shelf_level(self.shelf_level_heights[level])
-                    self._cabinet_scan_fresh = True
-                else:
-                    CLog.manip(
-                        self, "PICK", "Reusing octomap from current visit (skipping shelf scan)."
-                    )
-            else:
-                self.subtask_manager.manipulation.move_to_position("table_stare")
-
+            yolo_name = self._to_yolo_name(item_name)
             self.subtask_manager.hri.say(f"I will pick the {item_name}.", wait=False)
 
-            yolo_name = self._to_yolo_name(item_name)
-
-            status = self.subtask_manager.manipulation.pick_object(
-                yolo_name, scan_environment=is_cabinet
-            )
+            if is_cabinet:
+                # Per-level detect-then-pick so a high-shelf object (e.g. cereal on L3)
+                # is framed and picked; table_stare frames only the lower levels.
+                status = self._pick_from_shelf(yolo_name, self.shelf_level_heights)
+                self._cabinet_scan_fresh = True  # the per-level scan refreshed the octomap
+            else:
+                self.subtask_manager.manipulation.move_to_position("table_stare")
+                status = self.subtask_manager.manipulation.pick_object(
+                    yolo_name, scan_environment=False
+                )
 
             # Verify gripper actually has the object
             if status == Status.EXECUTION_SUCCESS:

--- a/task_manager/task_manager/utils/shelf_pick_logic.py
+++ b/task_manager/task_manager/utils/shelf_pick_logic.py
@@ -1,0 +1,47 @@
+"""Pure decision logic for per-level shelf picking (no ROS, unit-testable offline).
+Mirrors the level-assignment rule used by storing_groceries."""
+
+# Defaults match storing_groceries. A detection is "on this level" if it sits just
+# below or up to UP_THRESHOLD above the level height.
+LEVEL_UP_THRESHOLD = 0.20
+LEVEL_DOWN_THRESHOLD = 0.05
+
+
+def height_matches_level(
+    height: float,
+    level_height: float,
+    up_threshold: float = LEVEL_UP_THRESHOLD,
+    down_threshold: float = LEVEL_DOWN_THRESHOLD,
+) -> bool:
+    """True if a detection at `height` belongs to the shelf at `level_height`."""
+    distance = height - level_height
+    if distance < 0:
+        return abs(distance) < down_threshold
+    return distance < up_threshold
+
+
+def _name_matches(target: str, name: str) -> bool:
+    t = (target or "").lower()
+    n = (name or "").lower()
+    if not t or not n:
+        return False
+    return t == n or t in n or n in t
+
+
+def find_target_on_level(
+    candidates,
+    target,
+    level_height,
+    up_threshold: float = LEVEL_UP_THRESHOLD,
+    down_threshold: float = LEVEL_DOWN_THRESHOLD,
+):
+    """First candidate matching target framed at level_height, else None.
+    candidates: (name, height) pairs; height None skips the height check."""
+    for name, height in candidates:
+        if not _name_matches(target, name):
+            continue
+        if height is None or height_matches_level(
+            height, level_height, up_threshold, down_threshold
+        ):
+            return (name, height)
+    return None


### PR DESCRIPTION
Shelf picks detected only from table_stare, which frames the lower levels, so objects on higher shelves weren't found, and the grasp approach/retract collided with the compartment ceiling.

- Detect at each shelf level and pick from the level where the object is found.
- On shelves, prefer a frontal grasp; a top-down approach hits the ceiling. Falls back to the unfiltered set if none qualify.
- After grasping, retract straight out toward the robot (dynamic distance) before moving away, so the arm clears the compartment. Table picks unchanged.

Tested on the robot at all three levels (yogurt, cereal, coke) without collision.
