### PR TITLE
Make manipulation safeguard opt-in (default off)

### DIFF
--- a/manipulation/packages/pick_and_place/launch/pick_and_place.launch.py
+++ b/manipulation/packages/pick_and_place/launch/pick_and_place.launch.py
@@ -7,6 +7,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+from launch.conditions import IfCondition
 
 
 def generate_launch_description():
@@ -103,6 +104,9 @@ def generate_launch_description():
             Node(
                 package="manipulation_general",
                 executable="manipulation_safeguard.py",
+                condition=IfCondition(
+                    LaunchConfiguration("enable_safeguard", default="false")
+                ),
                 output="screen",
                 emulate_tty=True,
                 parameters=[sim_time_param],


### PR DESCRIPTION
## What
Gate the `manipulation_safeguard` node behind a launch arg `enable_safeguard` (default `false`).

## Why
The safeguard over-triggers and halts the arm mid-trajectory (servo motor 5 error + a latched e-stop on `/manipulation/estop`), which silently blocks normal picks. Making it opt-in keeps picks running by default while the node stays available.

## Enable
`ros2 launch pick_and_place pick_and_place.launch.py enable_safeguard:=true`

No behavior change when enabled.