### PR TITLE
Add approach_direction navigation pipeline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,6 +30,3 @@
 [submodule "navigation/packages/ira_laser_tools"]
 	path = navigation/packages/ira_laser_tools
 	url = https://github.com/ryanpennings/ira_laser_tools
-[submodule "navigation/packages/ros2_laser_scan_merger"]
-	path = navigation/packages/ros2_laser_scan_merger
-	url = https://github.com/mich1342/ros2_laser_scan_merger.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 [submodule "navigation/packages/ira_laser_tools"]
 	path = navigation/packages/ira_laser_tools
 	url = https://github.com/ryanpennings/ira_laser_tools
+[submodule "navigation/packages/ros2_laser_scan_merger"]
+	path = navigation/packages/ros2_laser_scan_merger
+	url = https://github.com/mich1342/ros2_laser_scan_merger.git

--- a/frida_constants/frida_constants/navigation_constants.py
+++ b/frida_constants/frida_constants/navigation_constants.py
@@ -51,7 +51,9 @@ POINT_CLOUD_TOPIC = "/point_cloud"  # filtered ZED cloud also used by nav2
 # nearest lidar reading in that direction is N cm away). Same layering as docking:
 #   task_manager -> APPROACH_DIRECTION_SERVICE (nav_central, public)
 #                -> APPROACH_DIRECTION_EXEC_SERVICE (approach_direction.py worker)
-APPROACH_DIRECTION_SERVICE = "/navigation/approach_direction"  # frida_interfaces/ApproachDirection (public)
+APPROACH_DIRECTION_SERVICE = (
+    "/navigation/approach_direction"  # frida_interfaces/ApproachDirection (public)
+)
 APPROACH_DIRECTION_EXEC_SERVICE = (
     "/navigation/approach_direction_exec"  # ApproachDirection: worker control loop
 )

--- a/frida_constants/frida_constants/navigation_constants.py
+++ b/frida_constants/frida_constants/navigation_constants.py
@@ -47,6 +47,15 @@ DOCK_PREVIEW_SERVICE = (
 DOCKED_TOPIC = "/navigation/docked"  # std_msgs/Bool (latched): currently docked?
 POINT_CLOUD_TOPIC = "/point_cloud"  # filtered ZED cloud also used by nav2
 
+# Approach-direction pipeline (strafe/drive in a commanded direction until the
+# nearest lidar reading in that direction is N cm away). Same layering as docking:
+#   task_manager -> APPROACH_DIRECTION_SERVICE (nav_central, public)
+#                -> APPROACH_DIRECTION_EXEC_SERVICE (approach_direction.py worker)
+APPROACH_DIRECTION_SERVICE = "/navigation/approach_direction"  # frida_interfaces/ApproachDirection (public)
+APPROACH_DIRECTION_EXEC_SERVICE = (
+    "/navigation/approach_direction_exec"  # ApproachDirection: worker control loop
+)
+
 ### General Constants
 MONITOR_RATE = 1.0
 NO_TF_LIMIT = 2

--- a/frida_interfaces/CMakeLists.txt
+++ b/frida_interfaces/CMakeLists.txt
@@ -173,6 +173,7 @@ set(srv_files
   "navigation/srv/MoveLocation.srv"
   "navigation/srv/NavQuery.srv"
   "navigation/srv/DockTable.srv"
+  "navigation/srv/ApproachDirection.srv"
 )
 
 # Generate interfaces only keep the necessary runtimes (python, c++)

--- a/frida_interfaces/navigation/srv/ApproachDirection.srv
+++ b/frida_interfaces/navigation/srv/ApproachDirection.srv
@@ -1,0 +1,10 @@
+# Request
+# Drive/strafe the holonomic omnibase in a commanded direction until the nearest
+# lidar reading in that direction is distance_cm away, then stop. No detection,
+# no alignment — the direction is given, not derived.
+string direction         # "forwards" | "backwards" | "left" | "right"
+float32 distance_cm      # stop when nearest reading in that direction <= this (cm)
+---
+# Response
+bool success
+string error

--- a/navigation/packages/nav_main/launch/task_launch/general_navigation.launch.py
+++ b/navigation/packages/nav_main/launch/task_launch/general_navigation.launch.py
@@ -133,6 +133,15 @@ def launch_function(context, *args, **kwargs):
         output='screen',
     )
 
+    # Approach-direction worker (strafe/drive in a commanded direction to N cm).
+    # Omnibase-only, same as table_docker (left/right need holonomic strafing).
+    approach_direction = Node(
+        package='nav_main',
+        executable='approach_direction.py',
+        name='approach_direction',
+        output='screen',
+    )
+
     launch_actions = [
         nav_central_node,
         nav_ui_node,
@@ -147,6 +156,7 @@ def launch_function(context, *args, **kwargs):
             launch_actions.append(omni_localization)
         launch_actions.append(nav2_omni)
         launch_actions.append(table_docker)
+        launch_actions.append(approach_direction)
 
     return launch_actions
 

--- a/navigation/packages/nav_main/scripts/approach_direction.py
+++ b/navigation/packages/nav_main/scripts/approach_direction.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Approach Direction — drive/strafe the holonomic omnibase in a COMMANDED
+direction (forwards/backwards/left/right) until the nearest lidar reading in that
+direction is N cm away, then stop.
+
+This is the simpler sibling of table_docker.py: the direction is GIVEN by the
+caller, not derived from the scan, so there is no RANSAC, no face locking, no TF
+reprojection, and no yaw/lateral alignment. The only control problem is "drive at
+a proportional speed along one fixed base_link axis, using the live
+nearest-reading-in-that-direction as the stopping condition".
+
+Layering (mirrors table_docker / nav_central):
+    task_manager -> ApproachDirection @ APPROACH_DIRECTION_SERVICE (nav_central)
+                 -> ApproachDirection @ APPROACH_DIRECTION_EXEC_SERVICE (this node)
+
+It runs only inside the service callback — no free-running timer. Holonomic base
+only (left/right need strafing), so it is launched omnibase-only like table_docker.
+"""
+
+import math
+import time
+import threading
+
+import numpy as np
+
+import rclpy
+from rclpy.node import Node
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup, ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.qos import qos_profile_sensor_data
+from rcl_interfaces.msg import SetParametersResult
+
+from geometry_msgs.msg import TwistStamped
+from sensor_msgs.msg import LaserScan
+
+from frida_constants.navigation_constants import (
+    APPROACH_DIRECTION_EXEC_SERVICE,
+    SCAN_TOPIC,
+)
+from frida_interfaces.srv import ApproachDirection
+
+
+# Direction name -> center angle in base_link (rad) and the (vx_sign, vy_sign) of
+# the unit motion vector. forwards = +x, left = +y (REP-103).
+_DIRECTIONS = {
+    "forwards": (0.0, (1.0, 0.0)),
+    "forward": (0.0, (1.0, 0.0)),
+    "backwards": (math.pi, (-1.0, 0.0)),
+    "backward": (math.pi, (-1.0, 0.0)),
+    "left": (math.pi / 2.0, (0.0, 1.0)),
+    "right": (-math.pi / 2.0, (0.0, -1.0)),
+}
+
+# Aliases → canonical key used for per-direction parameters and cone lookup.
+_CANONICAL = {
+    "forwards": "forwards", "forward": "forwards",
+    "backwards": "backwards", "backward": "backwards",
+    "left": "left", "right": "right",
+}
+
+
+class ApproachDirectionNode(Node):
+    def __init__(self):
+        super().__init__("approach_direction")
+
+        # --- Topics / frames ---
+        self.cmd_vel_topic = self.declare_parameter("cmd_vel_topic", "/cmd_vel").value
+        self.scan_topic = self.declare_parameter("scan_topic", SCAN_TOPIC).value
+        self.base_frame = self.declare_parameter("base_frame", "base_link").value
+
+        # --- Per-direction angular windows (asymmetric offsets from direction center) ---
+        # Each direction exposes {dir}_angle_min_deg / {dir}_angle_max_deg as runtime
+        # parameters. Values are offsets in degrees relative to the direction's center
+        # angle (0° for forwards, 180° for backwards, 90° for left, -90° for right).
+        # Defaults ±15°. Stored internally in radians as (min, max) tuples.
+        self._direction_cones: dict[str, tuple[float, float]] = {}
+        for d in ("forwards", "backwards", "left", "right"):
+            mn = float(self.declare_parameter(f"{d}_angle_min_deg", -15.0).value)
+            mx = float(self.declare_parameter(f"{d}_angle_max_deg",  15.0).value)
+            self._direction_cones[d] = (math.radians(mn), math.radians(mx))
+
+        self.max_detect_range = self.declare_parameter("max_detect_range", 3.0).value
+
+        # --- Per-direction body offset (base_link -> FOOTPRINT EDGE in that dir) ---
+        # The requested distance_cm is the gap from the robot's FOOTPRINT EDGE in
+        # the commanded direction to the obstacle (clearance = nearest_reading -
+        # offset), so it matches the footprint nav2 uses for collision.
+        #
+        # Defaults are the half-extents of the omnibase nav2 footprint
+        #   nav2_omni.yaml: [ [0.325, 0.25], [0.325,-0.25], [-0.325,-0.25], [-0.325,0.25] ]
+        #   -> front/back = 0.325 m, left/right = 0.25 m (in base_link).
+        self.offset_forwards = self.declare_parameter("offset_forwards", 0.325).value
+        self.offset_backwards = self.declare_parameter("offset_backwards", 0.325).value
+        self.offset_left = self.declare_parameter("offset_left", 0.25).value
+        self.offset_right = self.declare_parameter("offset_right", 0.25).value
+
+        # --- Approach targets / safety ---
+        self.min_safe = self.declare_parameter("min_safe", 0.05).value      # hard floor (m, from body offset)
+        self.dist_tol = self.declare_parameter("dist_tol", 0.03).value
+
+        # --- Control gains / limits ---
+        self.k = self.declare_parameter("k", 0.9).value
+        self.max_vx = self.declare_parameter("max_vx", 0.22).value
+        self.max_vy = self.declare_parameter("max_vy", 0.30).value
+        self.min_v = self.declare_parameter("min_v", 0.04).value            # crawl floor near the goal
+        self.control_rate = self.declare_parameter("control_rate", 15.0).value
+        self.approach_timeout = self.declare_parameter("approach_timeout", 40.0).value
+        self.settle_cycles = int(self.declare_parameter("settle_cycles", 3).value)
+
+        # --- Debug scan republishing ---
+        # When pub_scan_debug is true, each incoming /scan is filtered to only the
+        # angular window of scan_debug_direction and republished on scan_debug_topic.
+        # All out-of-window ranges are set to inf so the LaserScan shape is preserved.
+        self.pub_scan_debug = bool(self.declare_parameter("pub_scan_debug", False).value)
+        self.scan_debug_direction = str(
+            self.declare_parameter("scan_debug_direction", "forwards").value
+        )
+        scan_debug_topic = str(
+            self.declare_parameter("scan_debug_topic", "/scan_direction").value
+        )
+
+        # --- State ---
+        self._lock = threading.Lock()
+        self._scan: LaserScan | None = None
+
+        sensor_cb = ReentrantCallbackGroup()
+        srv_cb = MutuallyExclusiveCallbackGroup()
+
+        self.create_subscription(LaserScan, self.scan_topic, self._scan_cb,
+                                 qos_profile_sensor_data, callback_group=sensor_cb)
+        self.cmd_pub = self.create_publisher(TwistStamped, self.cmd_vel_topic, 10)
+        self._debug_pub = self.create_publisher(LaserScan, scan_debug_topic, 10)
+        self.create_service(ApproachDirection, APPROACH_DIRECTION_EXEC_SERVICE,
+                            self._approach_cb, callback_group=srv_cb)
+
+        self.add_on_set_parameters_callback(self._on_set_params)
+
+        cone_summary = {d: (round(math.degrees(v[0]), 1), round(math.degrees(v[1]), 1))
+                        for d, v in self._direction_cones.items()}
+        self.log("info", f"approach_direction ready. service={APPROACH_DIRECTION_EXEC_SERVICE} "
+                         f"scan={self.scan_topic} cones={cone_summary}")
+
+    # ------------------------------------------------------------------ utils
+    def _on_set_params(self, params):
+        for p in params:
+            name = p.name
+            # Per-direction cone parameters — must be matched before the generic fallback.
+            matched = False
+            for d in ("forwards", "backwards", "left", "right"):
+                if name == f"{d}_angle_min_deg":
+                    _, mx = self._direction_cones[d]
+                    self._direction_cones[d] = (math.radians(float(p.value)), mx)
+                    matched = True
+                    break
+                if name == f"{d}_angle_max_deg":
+                    mn, _ = self._direction_cones[d]
+                    self._direction_cones[d] = (mn, math.radians(float(p.value)))
+                    matched = True
+                    break
+            if matched:
+                continue
+            if name == "pub_scan_debug":
+                self.pub_scan_debug = bool(p.value)
+            elif name == "scan_debug_direction":
+                self.scan_debug_direction = str(p.value)
+            elif hasattr(self, name):
+                setattr(self, name, p.value)
+        return SetParametersResult(successful=True)
+
+    def log(self, level, msg):
+        text = f"ApproachDirection: {msg}"
+        if level == "warn":
+            self.get_logger().warn(text)
+        elif level == "error":
+            self.get_logger().error(text)
+        else:
+            self.get_logger().info(text)
+
+    def _scan_cb(self, msg: LaserScan):
+        with self._lock:
+            self._scan = msg
+        if self.pub_scan_debug:
+            self._publish_debug_scan(msg)
+
+    def _publish_debug_scan(self, scan: LaserScan):
+        """Republish scan filtered to the angular window of scan_debug_direction."""
+        direction = _CANONICAL.get(self.scan_debug_direction.strip().lower())
+        if direction is None:
+            return
+        center, _ = _DIRECTIONS[direction]
+        cone_min, cone_max = self._direction_cones[direction]
+
+        ranges = np.asarray(scan.ranges, dtype=float)
+        n = len(ranges)
+        angles = scan.angle_min + np.arange(n) * scan.angle_increment
+        da = np.arctan2(np.sin(angles - center), np.cos(angles - center))
+        in_cone = (da >= cone_min) & (da <= cone_max)
+        filtered = np.where(in_cone, ranges, np.inf)
+
+        out = LaserScan()
+        out.header = scan.header
+        out.angle_min = scan.angle_min
+        out.angle_max = scan.angle_max
+        out.angle_increment = scan.angle_increment
+        out.time_increment = scan.time_increment
+        out.scan_time = scan.scan_time
+        out.range_min = scan.range_min
+        out.range_max = scan.range_max
+        out.ranges = filtered.tolist()
+        out.intensities = scan.intensities
+        self._debug_pub.publish(out)
+
+    def _publish_cmd(self, vx=0.0, vy=0.0):
+        t = TwistStamped()
+        t.header.stamp = self.get_clock().now().to_msg()
+        t.header.frame_id = self.base_frame
+        t.twist.linear.x = float(vx)
+        t.twist.linear.y = float(vy)
+        t.twist.angular.z = 0.0
+        self.cmd_pub.publish(t)
+
+    def _stop(self):
+        self._publish_cmd(0.0, 0.0)
+
+    @staticmethod
+    def _clamp(v, lim):
+        return max(-lim, min(lim, v))
+
+    def _cone_nearest(self, canonical: str, center: float) -> float | None:
+        """Nearest scan range (m) within the per-direction angular window, or None."""
+        with self._lock:
+            scan = self._scan
+        if scan is None:
+            return None
+        ranges = np.asarray(scan.ranges, dtype=float)
+        n = len(ranges)
+        if n == 0:
+            return None
+        angles = scan.angle_min + np.arange(n) * scan.angle_increment
+        da = np.arctan2(np.sin(angles - center), np.cos(angles - center))
+        cone_min, cone_max = self._direction_cones[canonical]
+        valid = (
+            np.isfinite(ranges)
+            & (ranges > max(scan.range_min, 1e-3))
+            & (ranges < self.max_detect_range)
+            & (da >= cone_min)
+            & (da <= cone_max)
+        )
+        if not np.any(valid):
+            return None
+        return float(np.min(ranges[valid]))
+
+    def _direction_offset(self, canonical: str) -> float:
+        return getattr(self, f"offset_{canonical}", self.offset_forwards)
+
+    # ----------------------------------------------------------------- service
+    def _approach_cb(self, request, response):
+        direction = (request.direction or "").strip().lower()
+        if direction not in _DIRECTIONS:
+            response.success = False
+            response.error = (f"Unknown direction '{request.direction}'. Use one of: "
+                              f"forwards, backwards, left, right")
+            self.log("error", response.error)
+            self._stop()
+            return response
+
+        canonical = _CANONICAL[direction]
+        center, (sx, sy) = _DIRECTIONS[direction]
+        offset = self._direction_offset(canonical)
+        target_m = max(float(request.distance_cm), 0.0) / 100.0
+        max_speed = self.max_vx if sy == 0.0 else self.max_vy
+
+        cone_min, cone_max = self._direction_cones[canonical]
+        self.log("info", f"Approach '{direction}' until {target_m:.2f} m "
+                         f"(offset={offset:.2f} cone=[{math.degrees(cone_min):.1f}, "
+                         f"{math.degrees(cone_max):.1f}]deg)")
+
+        dt = 1.0 / self.control_rate
+        deadline = time.time() + self.approach_timeout
+        settled = 0
+
+        while rclpy.ok():
+            if time.time() > deadline:
+                self._stop()
+                response.success = False
+                response.error = "Approach timed out before reaching target distance"
+                self.log("error", response.error)
+                return response
+
+            nearest = self._cone_nearest(canonical, center)
+            clearance = None if nearest is None else (nearest - offset)
+
+            safety_stop = clearance is not None and clearance <= self.min_safe
+            at_target = clearance is not None and clearance <= target_m + self.dist_tol
+
+            if at_target or safety_stop:
+                settled += 1
+                if settled >= self.settle_cycles:
+                    self._stop()
+                    response.success = True
+                    near_txt = "--" if nearest is None else f"{nearest:.3f}"
+                    response.error = ""
+                    self.log("info", f"Reached: clearance="
+                             f"{'--' if clearance is None else round(clearance, 3)}m "
+                             f"nearest={near_txt}m")
+                    return response
+            else:
+                settled = 0
+
+            if clearance is None:
+                # Nothing within max_detect_range in this direction -> path is clear,
+                # drive at the capped speed (the timeout bounds a runaway).
+                speed = max_speed
+            else:
+                e = clearance - target_m
+                speed = self._clamp(self.k * e, max_speed)
+                if e > self.dist_tol and 0.0 < speed < self.min_v:
+                    speed = self.min_v
+                if clearance <= self.min_safe:
+                    speed = 0.0
+
+            self._publish_cmd(speed * sx, speed * sy)
+            time.sleep(dt)
+
+        self._stop()
+        response.success = False
+        response.error = "Approach aborted (shutdown)"
+        return response
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = ApproachDirectionNode()
+    executor = MultiThreadedExecutor()
+    executor.add_node(node)
+    try:
+        executor.spin()
+    except (KeyboardInterrupt, SystemExit):
+        pass
+    finally:
+        node._stop()
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/navigation/packages/nav_main/scripts/nav_central.py
+++ b/navigation/packages/nav_main/scripts/nav_central.py
@@ -46,13 +46,16 @@ from frida_constants.navigation_constants import(
         DOCK_SERVICE,
         DOCK_TABLE_SERVICE,
         DEFAULT_DOCK_OFFSET,
+        APPROACH_DIRECTION_SERVICE,
+        APPROACH_DIRECTION_EXEC_SERVICE,
         )
 from frida_interfaces.srv import (
         CheckDoor,
         MapAreas,
         MoveLocation,
         NavQuery,
-        DockTable
+        DockTable,
+        ApproachDirection
         )
 from ament_index_python.packages import get_package_share_directory
 import tf2_ros
@@ -153,6 +156,11 @@ class Nav_Central(Node):
             Trigger, DOCK_SERVICE, callback_group=self.rtab_service_group)
         self.dock_param_client = self.create_client(
             SetParameters, '/table_docker/set_parameters', callback_group=self.rtab_service_group)
+        # Approach-direction (strafe/drive in a commanded direction to N cm) client.
+        # No-op if the approach_direction worker node isn't running.
+        self.approach_direction_client = self.create_client(
+            ApproachDirection, APPROACH_DIRECTION_EXEC_SERVICE,
+            callback_group=self.rtab_service_group)
         # Costmap clear clients — wipe stale obstacle marks (e.g. from the parked/docked
         # pose) before a new goal so the planner/MPPI start from a clean slate.
         self.clear_local_costmap_client = self.create_client(
@@ -175,6 +183,7 @@ class Nav_Central(Node):
         
         self.move_location_srv = self.create_service(MoveLocation, MOVE_LOCATION_SERVICE, self.go_to_area, callback_group=self.service_group)
         self.dock_table_srv = self.create_service(DockTable, DOCK_TABLE_SERVICE, self.dock_table_callback, callback_group=self.service_group)
+        self.approach_direction_srv = self.create_service(ApproachDirection, APPROACH_DIRECTION_SERVICE, self.approach_direction_callback, callback_group=self.service_group)
         self.goal_action_client = ActionClient(self,NavigateToPose ,GOAL_NAV_ACTION_SERVER)
 
         # Path query service — distance/time between two areas without navigating
@@ -537,6 +546,41 @@ class Nav_Central(Node):
             self.nav_logger("info", "Dock_Table -> Docked")
         else:
             self.nav_logger("error", f"Dock_Table -> Failed: {message}")
+        return response
+
+    def _approach_direction(self, direction, distance_cm):
+        """Relay a directional approach to the approach_direction worker node.
+        Returns (success, message). Thin orchestrator — the control loop lives in
+        the worker, same split as _approach_table/table_docker."""
+        if not self.approach_direction_client.service_is_ready():
+            self.nav_logger("warn", "ApproachDirection -> worker node not available")
+            return (False, "approach_direction node not available")
+        req = ApproachDirection.Request()
+        req.direction = str(direction)
+        req.distance_cm = float(distance_cm)
+        self.nav_logger("info", f"ApproachDirection -> {direction} until {distance_cm} cm")
+        future = self.approach_direction_client.call_async(req)
+        elapsed = 0.0
+        while not future.done() and elapsed < 90.0:
+            self.get_clock().sleep_for(rclpy.duration.Duration(seconds=0.1))
+            elapsed += 0.1
+        if not future.done():
+            return (False, "approach_direction timed out")
+        res = future.result()
+        return (res.success, res.error)
+
+    def approach_direction_callback(self, request, response):
+        """Service: strafe/drive in a commanded direction until N cm away."""
+        self.nav_logger("info",
+                        f"ApproachDirection -> Service called "
+                        f"(direction={request.direction} distance_cm={request.distance_cm})")
+        success, message = self._approach_direction(request.direction, request.distance_cm)
+        response.success = success
+        response.error = message
+        if success:
+            self.nav_logger("info", "ApproachDirection -> Reached target")
+        else:
+            self.nav_logger("error", f"ApproachDirection -> Failed: {message}")
         return response
 
     def _clear_costmaps(self, settle_s=0.3):

--- a/task_manager/task_manager/subtask_managers/nav_tasks.py
+++ b/task_manager/task_manager/subtask_managers/nav_tasks.py
@@ -16,9 +16,17 @@ from frida_constants.navigation_constants import (
     MOVE_LOCATION_SERVICE,
     NAV_QUERY_SERVICE,
     DOCK_TABLE_SERVICE,
+    APPROACH_DIRECTION_SERVICE,
     SUBTASK_MANAGER,
 )
-from frida_interfaces.srv import CheckDoor, MapAreas, MoveLocation, NavQuery, DockTable
+from frida_interfaces.srv import (
+    CheckDoor,
+    MapAreas,
+    MoveLocation,
+    NavQuery,
+    DockTable,
+    ApproachDirection,
+)
 
 from task_manager.utils.decorators import mockable, service_check
 from task_manager.utils.colored_logger import CLog
@@ -40,6 +48,9 @@ class NavigationTasks:
         self.move_to_location_srv = self.node.create_client(MoveLocation, MOVE_LOCATION_SERVICE)
         self.nav_query_srv = self.node.create_client(NavQuery, NAV_QUERY_SERVICE)
         self.dock_table_srv = self.node.create_client(DockTable, DOCK_TABLE_SERVICE)
+        self.approach_direction_srv = self.node.create_client(
+            ApproachDirection, APPROACH_DIRECTION_SERVICE
+        )
 
         # Task Actions and Services check
         self.services = {
@@ -49,6 +60,7 @@ class NavigationTasks:
                 "move_to_location_srv": {"client": self.move_to_location_srv, "type": "service"},
                 "nav_query_srv": {"client": self.nav_query_srv, "type": "service"},
                 "dock_table_srv": {"client": self.dock_table_srv, "type": "service"},
+                "approach_direction_srv": {"client": self.approach_direction_srv, "type": "service"},
             },
         }
 
@@ -234,6 +246,38 @@ class NavigationTasks:
                 return (Status.EXECUTION_SUCCESS, "")
             else:
                 CLog.nav(self.node, "ERROR", f"Docking failed: {result.error}")
+                return (Status.EXECUTION_ERROR, result.error)
+        else:
+            CLog.nav(self.node, "ERROR", "Service request failed (None result)")
+            return (Status.EXECUTION_ERROR, "Error with request")
+
+    @mockable(return_value=(Status.EXECUTION_SUCCESS, ""), delay=3)
+    @service_check(
+        "approach_direction_srv",
+        (Status.EXECUTION_ERROR, "Service not started"),
+        timeout=SUBTASK_MANAGER.SERVICE_TIMEOUT.value,
+    )
+    def approach_direction(self, direction, distance_cm=10.0):
+        """Strafe/drive forwards|backwards|left|right until the nearest lidar
+        reading in that direction is distance_cm away (omnibase only).
+
+        direction: "forwards" | "backwards" | "left" | "right"
+        distance_cm: target clearance in centimeters.
+        """
+        CLog.nav(self.node, "MOVE",
+                 f"Requesting approach {direction} until {distance_cm} cm")
+        request = ApproachDirection.Request()
+        request.direction = str(direction)
+        request.distance_cm = float(distance_cm)
+        future = self.approach_direction_srv.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future)
+        result = future.result()
+        if result is not None:
+            if result.success:
+                CLog.nav(self.node, "SUCCESS", f"Approached {direction}")
+                return (Status.EXECUTION_SUCCESS, "")
+            else:
+                CLog.nav(self.node, "ERROR", f"Approach failed: {result.error}")
                 return (Status.EXECUTION_ERROR, result.error)
         else:
             CLog.nav(self.node, "ERROR", "Service request failed (None result)")

--- a/task_manager/task_manager/subtask_managers/nav_tasks.py
+++ b/task_manager/task_manager/subtask_managers/nav_tasks.py
@@ -60,7 +60,10 @@ class NavigationTasks:
                 "move_to_location_srv": {"client": self.move_to_location_srv, "type": "service"},
                 "nav_query_srv": {"client": self.nav_query_srv, "type": "service"},
                 "dock_table_srv": {"client": self.dock_table_srv, "type": "service"},
-                "approach_direction_srv": {"client": self.approach_direction_srv, "type": "service"},
+                "approach_direction_srv": {
+                    "client": self.approach_direction_srv,
+                    "type": "service",
+                },
             },
         }
 
@@ -264,8 +267,7 @@ class NavigationTasks:
         direction: "forwards" | "backwards" | "left" | "right"
         distance_cm: target clearance in centimeters.
         """
-        CLog.nav(self.node, "MOVE",
-                 f"Requesting approach {direction} until {distance_cm} cm")
+        CLog.nav(self.node, "MOVE", f"Requesting approach {direction} until {distance_cm} cm")
         request = ApproachDirection.Request()
         request.direction = str(direction)
         request.distance_cm = float(distance_cm)


### PR DESCRIPTION
Adds a holonomic strafe/drive primitive: given a direction (forwards, backwards, left, right) and a target clearance in cm, the robot drives until the nearest lidar reading in that direction reaches the target distance, measured from the footprint edge.

Architecture mirrors table_docker: nav_tasks → nav_central relay → approach_direction.py worker node with a proportional controller on /scan.

Tunable at runtime: per-direction angular windows ({dir}_angle_min/max_deg), footprint offsets, speed limits, and tolerances.

Debug: set pub_scan_debug:=true + scan_debug_direction to republish the filtered cone as /scan_direction for visualization.
