### PR TITLE
Make manipulation safeguard a global node-level toggle

### DIFF
--- a/manipulation/packages/manipulation_general/manipulation_general/manipulation_safeguard.py
+++ b/manipulation/packages/manipulation_general/manipulation_general/manipulation_safeguard.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import math
+import os
 import rclpy
 from rclpy.node import Node
 from rclpy.action import ActionClient
@@ -53,6 +54,20 @@ class ManipulationSafeguard(Node):
         self._recovering = False
         self._pending_target_angles: list[float] | None = None
 
+        # Global opt-in (default off via FRIDA_ENABLE_SAFEGUARD; ROS param overrides).
+        # Disabled = no autonomous estop/recovery; ensure_arm_ready stays available.
+        env_default = os.environ.get("FRIDA_ENABLE_SAFEGUARD", "false")
+        self._enable_safeguard = self.declare_parameter(
+            "enable_safeguard", env_default
+        ).get_parameter_value().string_value.strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+
+        # Always subscribe so _arm_state is populated for the on-demand ensure_arm_ready
+        # service; the autonomous estop broadcast in the callback is gated by the flag.
         self.create_subscription(
             RobotMsg,
             XARM_ROBOT_STATES_TOPIC,
@@ -108,11 +123,20 @@ class ManipulationSafeguard(Node):
             callback_group=self.callback_group,
         )
 
-        self.create_timer(
-            2.0, self._try_estop_recovery, callback_group=self.callback_group
-        )
+        # Autonomous recovery timer only when enabled; inert mode never auto-moves the arm.
+        if self._enable_safeguard:
+            self.create_timer(
+                2.0, self._try_estop_recovery, callback_group=self.callback_group
+            )
 
-        self.get_logger().info("Manipulation Safeguard node started")
+        mode = (
+            "full autonomous safeguard"
+            if self._enable_safeguard
+            else "INERT (ensure_arm_ready only; no autonomous estop or recovery)"
+        )
+        self.get_logger().info(
+            f"Manipulation Safeguard node started: enable_safeguard={self._enable_safeguard} [{mode}]"
+        )
 
     def _handle_ensure_arm_ready(self, request, response):
         self._ensure_arm_ready()
@@ -136,6 +160,8 @@ class ManipulationSafeguard(Node):
 
     def _on_arm_state(self, msg: RobotMsg):
         self._arm_state = msg
+        if not self._enable_safeguard:
+            return  # inert: keep arm state for ensure_arm_ready, but never auto-estop
         is_fault = msg.state == XARM_STATE_STOPPED or msg.err != 0
         if is_fault and not self._in_estop:
             self._in_estop = True

--- a/manipulation/packages/pick_and_place/launch/pick_and_place.launch.py
+++ b/manipulation/packages/pick_and_place/launch/pick_and_place.launch.py
@@ -7,7 +7,6 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch.conditions import IfCondition
 
 
 def generate_launch_description():
@@ -104,9 +103,6 @@ def generate_launch_description():
             Node(
                 package="manipulation_general",
                 executable="manipulation_safeguard.py",
-                condition=IfCondition(
-                    LaunchConfiguration("enable_safeguard", default="false")
-                ),
                 output="screen",
                 emulate_tty=True,
                 parameters=[sim_time_param],


### PR DESCRIPTION
The `enable_safeguard` flag only existed as a launch argument in `pick_and_place.launch.py`, so the safeguard kept running under `hric` and any other launch that starts the node. This moves the toggle into the node so a single setting governs it everywhere.

`manipulation_safeguard` now reads `enable_safeguard`, defaulting from the `FRIDA_ENABLE_SAFEGUARD` env var (default `false`). When disabled it does not broadcast the autonomous e-stop and does not run the recovery timer, but it still serves `ensure_arm_ready`, so `motion_planning_server` keeps working without waiting on a missing service or losing on-demand recovery.

The launch-level `enable_safeguard` condition is removed so the node always starts and self-gates; keeping it would double-gate and drop `ensure_arm_ready`.

Enable with `FRIDA_ENABLE_SAFEGUARD=true` or `-p enable_safeguard:=true`.
