### PR TITLE
Robust shelf pick and place

### DIFF
--- a/manipulation/packages/arm_pkg/config/frida_eigen_params_custom_gripper_shelf.cfg
+++ b/manipulation/packages/arm_pkg/config/frida_eigen_params_custom_gripper_shelf.cfg
@@ -1,0 +1,104 @@
+# File from the home-manipulation repo: .............................
+# Path to config file for robot hand geometry
+hand_geometry_filename = 0
+
+# Path to config file for volume and image geometry
+image_geometry_filename = 0
+
+# ==== Robot Hand Geometry ====
+#   finger_width: the width of the finger
+#   outer_diameter: the diameter of the robot hand (= maximum aperture + 2 * finger width)
+#   hand_depth: the finger length (measured from hand base to finger tip)
+#   hand_height: the height of the hand
+#   init_bite: the minimum amount of the object to be covered by the hand
+
+# SF Gripper
+finger_width = 0.025
+hand_outer_diameter = 0.15
+hand_depth =  0.08
+hand_height = 0.05
+init_bite = 0.05
+
+# ==== Grasp Descriptor ====
+#   volume_width: the width of the cube inside the robot hand
+#   volume_depth: the depth of the cube inside the robot hand
+#   volume_height: the height of the cube inside the robot hand
+#   image_size: the size of the image (width and height; image is square)
+#   image_num_channels: the number of image channels
+
+# DASHGO
+volume_width = 0.09 # hand_outer_diameter - 2 * finger_width
+volume_depth = 0.08
+volume_height = 0.05
+image_size = 60
+image_num_channels = 15 
+
+# (OpenVINO) Path to directory that contains neural network parameters
+weights_file = /workspace/src/manipulation/packages/gpd/models/lenet/15channels/params/
+
+# Preprocessing of point cloud
+#   voxelize: if the cloud gets voxelized/downsampled
+#   remove_outliers: if statistical outliers are removed from the cloud (used to remove noise)
+#   workspace: the workspace of the robot (dimensions of a cube centered at origin of point cloud)
+#   camera_position: the position of the camera from which the cloud was taken
+#   sample_above_plane: only draws samples which do not belong to the table plane
+voxelize = 1
+remove_outliers = 1
+workspace = -1.5 1.5 -1.5 1.5 -1.5 1.5
+camera_position = 0 0.06 1.17
+sample_above_plane = 0
+
+# Grasp candidate generation
+#   num_samples: the number of samples to be drawn from the point cloud
+#   num_threads: the number of CPU threads to be used
+#   nn_radius: the radius for the neighborhood search
+#   num_orientations: the number of robot hand orientations to evaluate
+#   rotation_axes: the axes about which the point neighborhood gets rotated
+num_samples = 2000
+num_threads = 8
+nn_radius = 0.02
+num_orientations = 8
+num_finger_placements = 10
+hand_axes = 2
+deepen_hand = 1
+
+# Filtering of candidates
+#   min_aperture: the minimum gripper width
+#   max_aperture: the maximum gripper width
+#   workspace_grasps: dimensions of a cube centered at origin of point cloud; should be smaller than <workspace>
+min_aperture = 0.0
+max_aperture = 0.085
+workspace_grasps = -1.4 1.4 -1.4 1.4 -1.4 1.4
+
+# Filtering of candidates based on their approach direction
+#   filter_approach_direction: turn filtering on/off
+#   direction: the direction to compare against
+#   angle_thresh: angle in radians above which grasps are filtered
+filter_approach_direction = 1
+direction = 1 0 -0.25 # frontal, tilted ~14deg down to match the oblique shelf view
+# ~54 degrees, matches the downstream is_frontal_grasp 60deg gate (0.52 = ~30deg over-pruned)
+thresh_rad = 0.95
+
+# Clustering of grasps
+#   min_inliers: minimum number of inliers per cluster; set to 0 to turn off clustering
+min_inliers = 1
+
+# Grasp selection
+#   num_selected: number of selected grasps (sorted by score)
+num_selected = 15
+
+# Visualization
+#   plot_normals: plot the surface normals
+#   plot_samples: plot the samples
+#   plot_candidates: plot the grasp candidates
+#   plot_filtered_candidates: plot the grasp candidates which remain after filtering
+#   plot_valid_grasps: plot the candidates that are identified as valid grasps
+#   plot_clustered_grasps: plot the grasps that after clustering
+#   plot_selected_grasps: plot the selected grasps (final output)
+plot_normals = 0
+plot_samples = 0
+plot_candidates = 0
+plot_filtered_candidates = 0
+plot_valid_grasps = 0
+plot_clustered_grasps = 0
+plot_selected_grasps = 0

--- a/manipulation/packages/pick_and_place/pick_and_place/keyboard_input.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/keyboard_input.py
@@ -17,6 +17,7 @@ from frida_constants.manipulation_constants import (
     MANIPULATION_ACTION_SERVER,
 )
 from frida_interfaces.srv import GetOptimalPositionForPlane
+from std_srvs.srv import Empty
 import json
 
 
@@ -48,6 +49,9 @@ class KeyboardInput(Node):
             GetOptimalPositionForPlane,
             "/manipulation/get_optimal_position_for_plane",
             callback_group=callback_group,
+        )
+        self._clear_octomap_client = self.create_client(
+            Empty, "/clear_octomap", callback_group=callback_group
         )
         self.objects = []  # Example list of objects
 
@@ -95,7 +99,9 @@ class KeyboardInput(Node):
             ):
                 self.objects.append(detection.label_text)
 
-    def send_pick_request(self, object_name, scan_environment=False):
+    def send_pick_request(
+        self, object_name, scan_environment=False, in_configuration=False
+    ):
         self.get_logger().warning(f"Sending pick request for: {object_name}")
 
         if not self._action_client.wait_for_server(timeout_sec=5.0):
@@ -108,6 +114,7 @@ class KeyboardInput(Node):
         goal_msg.pick_params.min_distance = self.min_distance
         goal_msg.pick_params.max_distance = self.max_distance
         goal_msg.scan_environment = scan_environment
+        goal_msg.pick_params.in_configuration = in_configuration
         self.get_logger().info(f"Sending pick request for: {object_name}")
         future = self._action_client.send_goal_async(
             goal_msg, feedback_callback=self.feedback_callback
@@ -115,26 +122,40 @@ class KeyboardInput(Node):
         future.add_done_callback(lambda f: self.goal_response_callback(f, object_name))
         self.get_logger().info(f"Pick request for {object_name} sent")
 
+    def _position_at_level(self, height):
+        """Face one shelf level (build octomap/spheres at that Z). Returns True if valid."""
+        if not self._optimal_position_client.wait_for_service(timeout_sec=5.0):
+            self.get_logger().error("get_optimal_position_for_plane not available!")
+            return False
+        req = GetOptimalPositionForPlane.Request()
+        req.plane_est_min_height = height - SHELF_SCAN_TOLERANCE
+        req.plane_est_max_height = height + SHELF_SCAN_TOLERANCE
+        req.table_or_shelf = False
+        req.approach_plane = True
+        self.get_logger().info(f"Positioning at shelf level {height:.3f} m")
+        future = self._optimal_position_client.call_async(req)
+        rclpy.spin_until_future_complete(self, future, timeout_sec=30.0)
+        result = future.result()
+        ok = result is not None and result.is_valid
+        if not ok:
+            self.get_logger().warning(f"Level {height:.3f} m: no valid position")
+        return ok
+
+    def _clear_octomap(self, settle=2.0):
+        """Clear the accumulated octomap (arm captured as obstacle, stale voxels) so a
+        deep/tight shelf grasp is not over-restricted; mirrors the FSM before a pick."""
+        if self._clear_octomap_client.wait_for_service(timeout_sec=2.0):
+            self._clear_octomap_client.call_async(Empty.Request())
+            self.get_logger().info("Cleared octomap; settling before pick")
+            time.sleep(settle)
+        else:
+            self.get_logger().warning("clear_octomap unavailable")
+
     def scan_shelf_levels(self):
         """Face each shelf level so the octomap/spheres build before a shelf pick or
         place. Mirrors the task manager cabinet scan; run before option -4 or -11."""
-        if not self._optimal_position_client.wait_for_service(timeout_sec=5.0):
-            self.get_logger().error("get_optimal_position_for_plane not available!")
-            return
         for height in SHELF_LEVEL_HEIGHTS:
-            req = GetOptimalPositionForPlane.Request()
-            req.plane_est_min_height = height - SHELF_SCAN_TOLERANCE
-            req.plane_est_max_height = height + SHELF_SCAN_TOLERANCE
-            req.table_or_shelf = False
-            req.approach_plane = True
-            self.get_logger().info(f"Scanning shelf level at {height:.3f} m")
-            future = self._optimal_position_client.call_async(req)
-            rclpy.spin_until_future_complete(self, future, timeout_sec=30.0)
-            result = future.result()
-            if result is None or not result.is_valid:
-                self.get_logger().warning(f"Level {height:.3f} m: no valid position")
-            else:
-                self.get_logger().info(f"Level {height:.3f} m positioned")
+            self._position_at_level(height)
             time.sleep(2.0)
         self.get_logger().info("Shelf scan done; now pick (-11) or place (-4).")
 
@@ -360,7 +381,26 @@ def main(args=None):
 
             elif choice == "-11":
                 object_name = input("Enter object name on shelf: ")
-                node.send_pick_request(object_name, scan_environment=True)
+                lvl = input(
+                    f"Shelf level 1-{len(SHELF_LEVEL_HEIGHTS)} (Enter = keep current pose): "
+                ).strip()
+                if lvl:
+                    try:
+                        idx = int(lvl) - 1
+                        if 0 <= idx < len(SHELF_LEVEL_HEIGHTS):
+                            node._position_at_level(SHELF_LEVEL_HEIGHTS[idx])
+                        else:
+                            print("Level out of range; keeping current pose.")
+                    except ValueError:
+                        print("Invalid level; keeping current pose.")
+                # Clear the accumulated octomap (FSM does this) so the deep grasp's IK
+                # config is not over-restricted by stale/arm voxels.
+                node._clear_octomap()
+                # in_configuration=True keeps the frontal level pose (else PickManager
+                # re-stares to table_stare and GPD sees the wrong view).
+                node.send_pick_request(
+                    object_name, scan_environment=True, in_configuration=True
+                )
 
             elif choice == "-12":
                 node.scan_shelf_levels()

--- a/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/managers/PickManager.py
@@ -46,6 +46,15 @@ CFG_PATHS = [
     ],
 ]
 
+# Shelf picks use a frontal-biased cfg with a wider approach cone (the table 30deg cone
+# over-prunes the oblique shelf view); selected only when is_shelf.
+SHELF_CFG_PATHS = [
+    [
+        "/workspace/src/manipulation/packages/arm_pkg/config/frida_eigen_params_custom_gripper_shelf.cfg",
+        False,
+    ],
+]
+
 
 # FINE HEIGHT ADJUSTMENT FOR CUTLERY
 # If it's floating, use negative values (e.g. -0.02)
@@ -312,7 +321,12 @@ class PickManager:
         else:
             # Shelf collision is handled by the sphere generation; the cavity boxes
             # over-constrained the narrow grasp (OMPL found no plan), so leave them off.
-            for CFG_PATH in CFG_PATHS:
+            # Retry the shelf detection a few times: GPD samples randomly, so re-detecting
+            # yields different grasps and recovers a round where all were unreachable.
+            cfg_list = SHELF_CFG_PATHS * 3 if is_shelf else CFG_PATHS
+            for CFG_PATH in cfg_list:
+                if pick_result_success:
+                    break
                 cfg_path = CFG_PATH[0]
                 is_reversible = CFG_PATH[1]
                 if is_reversible and height < 0.06:
@@ -327,7 +341,13 @@ class PickManager:
                 if len(grasp_poses) == 0:
                     continue
 
-                if len(grasp_poses) > 5:
+                if is_shelf:
+                    # Keep the highest-scored candidates (not a random 5) and try more of
+                    # them, so a reachable, higher-quality grasp wins over a marginal one.
+                    order = list(np.argsort(grasp_scores)[::-1][:8])
+                    grasp_poses = [grasp_poses[i] for i in order]
+                    grasp_scores = [grasp_scores[i] for i in order]
+                elif len(grasp_poses) > 5:
                     indices = np.random.choice(len(grasp_poses), size=5, replace=False)
                     grasp_poses = [grasp_poses[i] for i in indices]
                     grasp_scores = [grasp_scores[i] for i in indices]
@@ -389,6 +409,30 @@ class PickManager:
                             f"Frontal grasp filter removed all for {object_name}; "
                             "using unfiltered set"
                         )
+
+                    # The ZED hangs ~10cm below the gripper and physically grazes the shelf
+                    # surface on a low frontal grasp; flip 180 about approach to lift it (same grasp).
+                    zed = np.array([-0.096, 0.0, 0.041])
+                    for pose in new_grasp_poses:
+                        q = [
+                            pose.pose.orientation.x,
+                            pose.pose.orientation.y,
+                            pose.pose.orientation.z,
+                            pose.pose.orientation.w,
+                        ]
+                        Rg = R.from_quat(q)
+                        cam0 = pose.pose.position.z + float(Rg.apply(zed)[2])
+                        q_flip = (Rg * R.from_euler("z", 180, degrees=True)).as_quat()
+                        cam1 = pose.pose.position.z + float(
+                            R.from_quat(q_flip).apply(zed)[2]
+                        )
+                        if cam1 > cam0:
+                            (
+                                pose.pose.orientation.x,
+                                pose.pose.orientation.y,
+                                pose.pose.orientation.z,
+                                pose.pose.orientation.w,
+                            ) = q_flip
 
                 goal_msg = PickMotion.Goal()
                 goal_msg.grasping_poses = new_grasp_poses

--- a/manipulation/packages/pick_and_place/pick_and_place/managers/PlaceManager.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/managers/PlaceManager.py
@@ -88,17 +88,26 @@ class PlaceManager:
 
         self.node.get_logger().info("Returning to position")
 
-        # return to configured position
-        for i in range(5):
-            back_res = send_joint_goal(
-                move_joints_action_client=self.node._move_joints_client,
-                named_position="table_stare",
-                velocity=0.5,
-            )
-            if back_res:
-                self.node.get_logger().info("Returned to position successfully")
-                break
-            self.node.get_logger().info("Retry sending return joint goal")
+        # The eye-in-hand octomap never sees the compartment ceiling, so add an explicit
+        # collision slab there (place surface + 0.34 m) before planning the return.
+        if place_params.is_shelf:
+            self.node.add_shelf_ceiling_guard(place_pose, place_params.table_height)
+
+        try:
+            for i in range(5):
+                back_res = send_joint_goal(
+                    move_joints_action_client=self.node._move_joints_client,
+                    named_position="table_stare",
+                    velocity=0.5,
+                )
+                if back_res:
+                    self.node.get_logger().info("Returned to position successfully")
+                    break
+                self.node.get_logger().info("Retry sending return joint goal")
+        finally:
+            # Always drop the guard so it does not constrain later motions.
+            if place_params.is_shelf:
+                self.node.remove_shelf_ceiling_guard()
 
         return return_result
 

--- a/manipulation/packages/pick_and_place/pick_and_place/manipulation_core.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/manipulation_core.py
@@ -12,7 +12,7 @@ from frida_motion_planning.utils.service_utils import (
 from std_srvs.srv import SetBool, Empty
 from std_msgs.msg import Bool
 from frida_interfaces.action import MoveJoints
-from frida_interfaces.msg import ManipulationTask
+from frida_interfaces.msg import ManipulationTask, CollisionObject
 from frida_interfaces.action import (
     PickMotion,
     PlaceMotion,
@@ -24,6 +24,7 @@ from frida_interfaces.srv import (
     GraspDetection,
     DetectionHandler,
     RemoveCollisionObject,
+    AddCollisionObjects,
     PlacePerceptionService,
     HeatmapPlace,
     GetJoints,
@@ -132,6 +133,11 @@ class ManipulationCore(Node):
         self._get_collision_objects_client = self.create_client(
             GetCollisionObjects,
             GET_COLLISION_OBJECTS_SERVICE,
+        )
+
+        self._add_collision_objects_client = self.create_client(
+            AddCollisionObjects,
+            "/manipulation/add_collision_objects",
         )
 
         qos = rclpy.qos.QoSProfile(
@@ -309,6 +315,44 @@ class ManipulationCore(Node):
         future = self._remove_collision_object_client.call_async(request)
         wait_for_future(future)
         return future.result().success
+
+    def add_shelf_ceiling_guard(self, place_pose, table_height):
+        """Block the place return from routing the arm up into the compartment ceiling
+        (the eye-in-hand octomap never sees it). Slab above the place surface."""
+        compartment_h = 0.34  # measured shelf level-to-ceiling height
+        co = CollisionObject()
+        co.id = "shelf_ceiling_guard"
+        co.type = "box"
+        co.pose.header.frame_id = place_pose.header.frame_id or "base_link"
+        co.pose.header.stamp = self.get_clock().now().to_msg()
+        co.pose.pose.position.x = float(place_pose.pose.position.x) + 0.10
+        co.pose.pose.position.y = float(place_pose.pose.position.y)
+        co.pose.pose.position.z = float(table_height) + compartment_h + 0.10
+        co.pose.pose.orientation.w = 1.0
+        co.dimensions.x = 0.40
+        co.dimensions.y = 0.80
+        co.dimensions.z = 0.20
+        request = AddCollisionObjects.Request()
+        request.collision_objects.append(co)
+        if not self._add_collision_objects_client.wait_for_service(timeout_sec=3.0):
+            self.get_logger().warn(
+                "add_collision_objects unavailable; no ceiling guard"
+            )
+            return
+        wait_for_future(
+            self._add_collision_objects_client.call_async(request), timeout=3.0
+        )
+        self.get_logger().info("Added shelf ceiling guard collision")
+
+    def remove_shelf_ceiling_guard(self):
+        """Remove the ceiling guard so it does not constrain later motions."""
+        request = RemoveCollisionObject.Request()
+        request.id = "shelf_ceiling_guard"
+        request.include_attached = False
+        if self._remove_collision_object_client.wait_for_service(timeout_sec=3.0):
+            wait_for_future(
+                self._remove_collision_object_client.call_async(request), timeout=3.0
+            )
 
     def clear_octomap(self):
         """Clear the octomap."""

--- a/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/pick_server.py
@@ -645,13 +645,7 @@ class PickMotionServer(Node):
                     return True, pick_result
 
                 else:
-                    # EE XY before reaching in, to size the retract dynamically.
-                    pre_state = self._latest_robot_state
-                    pre_xy = (
-                        (pre_state.pose[0] / 1000.0, pre_state.pose[1] / 1000.0)
-                        if pre_state is not None
-                        else None
-                    )
+                    # Pure GPD reach (simple plan straight to the grasp, what grasped before).
                     grasp_pose_handler, grasp_pose_result = self.move_to_pose(
                         ee_link_pose
                     )
@@ -668,55 +662,8 @@ class PickMotionServer(Node):
 
                     if result:
                         self.get_logger().info("Object attached")
-                        # Shelf pick (frontal grasp): pull straight out toward the
-                        # robot in XY (Z constant, clears ceiling). Table unchanged.
-                        approach = quat2mat(
-                            [
-                                ee_link_pose.pose.orientation.w,
-                                ee_link_pose.pose.orientation.x,
-                                ee_link_pose.pose.orientation.y,
-                                ee_link_pose.pose.orientation.z,
-                            ]
-                        )[:, 2]
-                        if abs(float(approach[2])) < 0.5:
-                            dist = SHELF_RETRACT_DIST
-                            post_state = self._latest_robot_state
-                            if pre_xy is not None and post_state is not None:
-                                depth = float(
-                                    np.hypot(
-                                        post_state.pose[0] / 1000.0 - pre_xy[0],
-                                        post_state.pose[1] / 1000.0 - pre_xy[1],
-                                    )
-                                )
-                                dist = min(
-                                    max(
-                                        depth + SHELF_RETRACT_MARGIN, SHELF_RETRACT_MIN
-                                    ),
-                                    SHELF_RETRACT_MAX,
-                                )
-                            ax = float(approach[0])
-                            ay = float(approach[1])
-                            na = float(np.hypot(ax, ay))
-                            if na > 1e-6:
-                                ux, uy = ax / na, ay / na
-                                retracted = False
-                                for frac in (1.0, 0.6, 0.35):
-                                    rp = copy.deepcopy(ee_link_pose)
-                                    rp.pose.position.x -= ux * dist * frac
-                                    rp.pose.position.y -= uy * dist * frac
-                                    self.get_logger().info(
-                                        f"Shelf retract: cartesian along -approach ({dist * frac:.3f} m)"
-                                    )
-                                    _, _res = self.move_to_pose(
-                                        rp, velocity=0.1, planner_id="cartesian"
-                                    )
-                                    if _res and _res.result.success:
-                                        retracted = True
-                                        break
-                                if not retracted:
-                                    self.get_logger().warn(
-                                        "Shelf retract: cartesian failed (singularity/collision?), skipping"
-                                    )
+                        # No shelf retract: switching to mode 5 with an object held opens the
+                        # gripper; let the front_stare return plan out collision-free instead.
                         pick_result.pick_pose = ee_link_pose
                         pick_result.grasp_score = goal_handle.request.grasping_scores[i]
 
@@ -1170,28 +1117,25 @@ class PickMotionServer(Node):
         self.collision_objects = self.get_collision_objects()
 
     def attach_pick_object(self):
-        obj_lowest = None
-        obj_highest = None
-        for obj in self.collision_objects:
-            if PICK_OBJECT_NAMESPACE in obj.id:
+        pick_objs = [o for o in self.collision_objects if PICK_OBJECT_NAMESPACE in o.id]
+        if not pick_objs:
+            return True, None, None
+        obj_lowest = min(pick_objs, key=lambda o: o.pose.pose.position.z)
+        obj_highest = max(pick_objs, key=lambda o: o.pose.pose.position.z)
+        # Attach only ONE box and drop the rest: attaching the whole cluster cloud (~15 boxes
+        # ahead of the gripper) over-constrained the return; front_stare/table_stare failed (-2).
+        for obj in pick_objs:
+            if obj.id == obj_lowest.id:
                 request = AttachCollisionObject.Request()
                 request.id = obj.id
-                if obj_lowest is None:
-                    obj_lowest = obj
-                else:
-                    if obj.pose.pose.position.z < obj_lowest.pose.pose.position.z:
-                        obj_lowest = obj
-                if obj_highest is None:
-                    obj_highest = obj
-                else:
-                    if obj.pose.pose.position.z > obj_highest.pose.pose.position.z:
-                        obj_highest = obj
                 request.attached_link = EEF_LINK_NAME
                 request.touch_links = EEF_CONTACT_LINKS
                 request.detach = False
                 self._attach_collision_object_client.wait_for_service()
                 future = self._attach_collision_object_client.call_async(request)
                 self.wait_for_future(future)
+            else:
+                self.remove_collision_object(obj.id)
         return True, obj_lowest, obj_highest
 
     def get_collision_objects(self):

--- a/manipulation/packages/pick_and_place/pick_and_place/place_server.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/place_server.py
@@ -38,6 +38,10 @@ import numpy as np
 from transforms3d.quaternions import quat2mat
 import time
 
+# Shelf place: how far (m) to pull the place toward the front edge so the arm and
+# eye-in-hand camera do not jam against the short compartment ceiling on a deep reach.
+SHELF_PLACE_DEPTH_BACK = 0.07
+
 
 class PlaceMotionServer(Node):
     def __init__(self):
@@ -136,6 +140,10 @@ class PlaceMotionServer(Node):
         for i in range(n_poses):
             ee_link_pose = copy.deepcopy(place_pose)
             ee_link_pose.pose.position.z += i * poses_dist
+            if is_shelf:
+                # The heatmap aims at the compartment center (deep), which jams the arm
+                # and camera against the ceiling; pull the place toward the front edge.
+                ee_link_pose.pose.position.x -= SHELF_PLACE_DEPTH_BACK
 
             ee_link_pre_pose = copy.deepcopy(ee_link_pose)
             ee_link_half_pose = copy.deepcopy(ee_link_pose)
@@ -248,14 +256,8 @@ class PlaceMotionServer(Node):
             time.sleep(1)
             self.get_logger().info("Gripper opened")
 
-            if is_shelf:
-                self.get_logger().info(
-                    f"Going back to pre-place pose: {ee_link_pre_pose}"
-                )
-                place_pose_handler, place_pose_result = self.move_to_pose(
-                    ee_link_pre_pose
-                )
-                self.get_logger().info(f"Pre-place pose result: {place_pose_result}")
+            # No place retract (mirror the shelf pick): return straight from the place pose.
+            # The cartesian retract left the wrist wound, so table_stare then aborted.
             return True
         self.get_logger().error("Failed to reach any grasp pose")
         return False

--- a/robot_description/frida_description/urdf/zed/zed.xacro
+++ b/robot_description/frida_description/urdf/zed/zed.xacro
@@ -20,7 +20,7 @@
                iyy="2.3258E-05" iyz="6.6645E-09" izz="0.00038297" />
     </inertial>
     <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
+      <origin xyz="-0.03 0 0.01404" rpy="0 0 0" />
       <geometry>
         <mesh filename="${mesh_path}ZED.STL" />
       </geometry>
@@ -29,7 +29,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
+      <origin xyz="-0.03 0 0.01404" rpy="0 0 0" />
       <geometry>
         <mesh filename="${mesh_path}ZED.STL" />
       </geometry>


### PR DESCRIPTION
Makes the shelf pick and place work reliably across the three cabinet levels.

Pick: fix the ZED mesh origin in the URDF (it was about 3cm forward and caused
false camera-shelf collisions that blocked deep frontal grasps), add a shelf GPD
config so grasps come in from the front, flip the grasp so the camera faces up,
and hold the level pose through the pick.

Place: pull the place toward the front edge so the arm and camera don't jam the
compartment ceiling on a deep reach, and add an explicit ceiling collision before
the return, since the eye-in-hand camera never looks up and the octomap has no
record of it.

Tested on hardware on levels 1, 2 and 3.
