### PR TITLE
Lower table dock retreat distance to 0.20 m

### DIFF
--- a/navigation/packages/nav_main/launch/task_launch/general_navigation.launch.py
+++ b/navigation/packages/nav_main/launch/task_launch/general_navigation.launch.py
@@ -131,6 +131,7 @@ def launch_function(context, *args, **kwargs):
         executable='table_docker.py',
         name='table_docker',
         output='screen',
+        parameters=[{'retreat_distance': 0.20}],
     )
 
     launch_actions = [


### PR DESCRIPTION
The base was backing off half a meter after docking, which was more than we need and crowded whatever sat behind the robot. Dropped the table_docker retreat to 0.20 m.