### PR TITLE
Fix optimal-position TF broadcast

### DIFF
--- a/manipulation/packages/pick_and_place/pick_and_place/fix_position_to_plane.py
+++ b/manipulation/packages/pick_and_place/pick_and_place/fix_position_to_plane.py
@@ -121,14 +121,14 @@ class FixPositionToPlane(Node):
 
         # Set translation
         transform.transform.translation.x = pose.pose.position.x
-        transform.transform.translation.y = pose.pose.position.x
-        transform.transform.translation.z = pose.pose.position.x
+        transform.transform.translation.y = pose.pose.position.y
+        transform.transform.translation.z = pose.pose.position.z
 
         # Set rotation
         transform.transform.rotation.x = pose.pose.orientation.x
-        transform.transform.rotation.y = pose.pose.orientation.x
-        transform.transform.rotation.z = pose.pose.orientation.x
-        transform.transform.rotation.w = pose.pose.orientation.x
+        transform.transform.rotation.y = pose.pose.orientation.y
+        transform.transform.rotation.z = pose.pose.orientation.z
+        transform.transform.rotation.w = pose.pose.orientation.w
 
         # Broadcast the transform
         self.tf_broadcaster.sendTransform(transform)


### PR DESCRIPTION
broadcast_transform was filling every translation and rotation field from .x, so the optimal_position frame came out NaN. That made get_optimal_position_for_plane return None and the shelf place fail. Fixed y/z/w to use the matching components.