### PR TITLE
Arm pointer: yield to manipulation on the xArm + keep gripper  closed on mode switches

### DIFF
--- a/frida_constants/frida_constants/manipulation_constants.py
+++ b/frida_constants/frida_constants/manipulation_constants.py
@@ -38,6 +38,10 @@ JOINTN_VELOCITY_MODE = 4
 
 MOVE_JOINTS_ACTION_SERVER = "/manipulation/move_joints_action_server"
 ESTOP_TOPIC = "/manipulation/estop"
+# Latched Bool: True while motion_planning_server is executing a MoveJoints/
+# MoveToPose goal (arm in use). nav_goal_arm_pointer yields the xArm mode while
+# this is True so it never fights manipulation for /xarm/set_mode.
+MANIPULATION_ARM_BUSY_TOPIC = "/manipulation/arm_busy"
 MOVE_TO_POSE_ACTION_SERVER = "/manipulation/move_to_pose_action_server"
 GET_JOINT_SERVICE = "/manipulation/get_joints"
 TOGGLE_SERVO_SERVICE = "/manipulation/toggle_servo"

--- a/manipulation/packages/frida_motion_planning/frida_motion_planning/motion_planning_server.py
+++ b/manipulation/packages/frida_motion_planning/frida_motion_planning/motion_planning_server.py
@@ -37,6 +37,7 @@ from frida_constants.manipulation_constants import (
     MIN_CONFIGURATION_DISTANCE_TRESHOLD,
     ESTOP_TOPIC,
     MANIPULATION_ENSURE_ARM_READY_SERVICE,
+    MANIPULATION_ARM_BUSY_TOPIC,
 )
 
 from frida_interfaces.msg import CollisionObject
@@ -46,7 +47,7 @@ from frida_motion_planning.utils.XArmServices import XArmServices
 
 from trajectory_msgs.msg import JointTrajectory
 from sensor_msgs.msg import JointState
-from rclpy.qos import QoSProfile
+from rclpy.qos import QoSProfile, DurabilityPolicy
 
 
 class MotionPlanningServer(Node):
@@ -71,6 +72,16 @@ class MotionPlanningServer(Node):
 
         self._in_estop = False
         self.current_mode = -1
+
+        # Latched "arm in use" flag so nav_goal_arm_pointer yields the xArm mode
+        # while a MoveJoints/MoveToPose goal executes (no /xarm/set_mode fight).
+        self._arm_busy = False
+        self._arm_busy_pub = self.create_publisher(
+            Bool,
+            MANIPULATION_ARM_BUSY_TOPIC,
+            QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL),
+        )
+        self._publish_busy(False)
 
         self.servo = MoveItServo(
             self,
@@ -206,6 +217,11 @@ class MotionPlanningServer(Node):
 
         self.get_logger().info("Motion Planning Action Server has been started")
 
+    def _publish_busy(self, busy: bool):
+        """Latch whether the arm is executing a goal (consumed by the arm pointer)."""
+        self._arm_busy = busy
+        self._arm_busy_pub.publish(Bool(data=busy))
+
     def move_to_pose_execute_callback(self, goal_handle):
         """Execute the pick action when a goal is received."""
         if self._in_estop:
@@ -221,6 +237,7 @@ class MotionPlanningServer(Node):
         feedback = MoveToPose.Feedback()
         result = MoveToPose.Result()
         self.set_planning_settings(goal_handle)
+        self._publish_busy(True)
         try:
             was_successful = self.move_to_pose(goal_handle, feedback)
             self.get_logger().info(
@@ -244,6 +261,7 @@ class MotionPlanningServer(Node):
         finally:
             self.get_logger().info("Resetting planning settings...")
             self.reset_planning_settings(goal_handle)
+            self._publish_busy(False)
 
         return result
 
@@ -295,6 +313,7 @@ class MotionPlanningServer(Node):
         self.get_logger().info("Executing joint goal action...")
         result = MoveJoints.Result()
         self.set_planning_settings(goal_handle)
+        self._publish_busy(True)
 
         try:
             # Here we call the worker and get the final result (True or False)
@@ -317,6 +336,7 @@ class MotionPlanningServer(Node):
 
         finally:
             self.reset_planning_settings(goal_handle)
+            self._publish_busy(False)
 
         return result
 

--- a/manipulation/packages/frida_motion_planning/scripts/nav_goal_arm_pointer.py
+++ b/manipulation/packages/frida_motion_planning/scripts/nav_goal_arm_pointer.py
@@ -4,7 +4,8 @@
 While /nav/goal_active is True, computes the bearing from the arm base to the nav
 goal and drives joint 1 toward it with direct xArm joint-velocity commands (the
 same API follow_face uses), holding all other joints. No MoveIt / motion planning.
-Stops and returns the arm to MoveIt mode when the goal goes inactive.
+When the goal goes inactive, hands the arm back to MoveIt and sends it to the named
+NAV_POSE (reliable front-facing pose) instead of velocity-homing joint1 by angle.
 """
 
 import math
@@ -12,6 +13,7 @@ import sys
 
 import rclpy
 from rclpy.node import Node
+from rclpy.action import ActionClient
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.qos import QoSProfile, DurabilityPolicy
 
@@ -30,6 +32,8 @@ from frida_constants.manipulation_constants import (
     XARM_SETSTATE_SERVICE,
     XARM_MOVEVELOCITY_SERVICE,
 )
+from frida_constants.xarm_configurations import NAV_POSE
+from frida_interfaces.action import MoveJoints
 from frida_motion_planning.utils.ros_utils import wait_for_future
 from frida_pymoveit2.robots import xarm6
 from xarm_msgs.srv import MoveVelocity, SetInt16
@@ -44,26 +48,26 @@ MAX_JOINT1_VEL = 0.5  # rad/s cap
 ANGLE_TOL = 0.02  # rad deadband (~1.1 deg) -> hold still
 VEL_DURATION = 0.3  # s; xArm auto-stops if we stop sending (safety if node dies)
 
-# ponytail: hardware calibration knobs, two INDEPENDENT angles. Tune on the robot.
-# JOINT1_SIGN flips rotation direction.
-# JOINT1_OFFSET aligns joint1's zero with the arm-base +x for GOAL TRACKING.
-#   0.0 is the value that made tracking point correctly. Do NOT change it to fix
-#   the homing pose -- that's what FRONT_OFFSET is for.
-# FRONT_OFFSET is the joint1 angle that faces the MOBILE-BASE FRONT, used only by
-#   the post-nav homing. Non-zero because the arm is mounted rotated vs the base.
-#   Tune this alone to fix where the arm ends after nav (here: -90deg).
+# ponytail: tracking calibration. JOINT1_SIGN flips rotation direction;
+# JOINT1_OFFSET aligns joint1's zero with the arm-base +x. 0.0 = tracking points
+# correctly. (The post-nav front pose is no longer tuned here -- see NAV_POSE.)
 JOINT1_SIGN = 1.0
 JOINT1_OFFSET = 0.0
-FRONT_OFFSET = -1.57
+
+# When the goal ends, instead of velocity-homing joint1 by angle (imprecise), hand
+# the arm to MoveIt and send it to the named NAV_POSE so it reliably faces front.
+MOVE_JOINTS_ACTION = "/manipulation/move_joints_action_server"
+NAV_POSE_VELOCITY = 0.75  # matches move_to_position default
+NAV_POSE_NAMES = list(NAV_POSE["joints"].keys())
+NAV_POSE_RADS = [
+    math.radians(v) if NAV_POSE.get("degrees") else float(v)
+    for v in NAV_POSE["joints"].values()
+]
 
 
 def wrap_angle(a: float) -> float:
     """Wrap to [-pi, pi]."""
     return math.atan2(math.sin(a), math.cos(a))
-
-
-# Joint1 target for the post-nav homing: faces the mobile-base front.
-FRONT_TARGET = max(-JOINT1_LIMIT, min(JOINT1_LIMIT, wrap_angle(FRONT_OFFSET)))
 
 
 def joint1_velocity(target: float, current: float) -> float:
@@ -83,10 +87,11 @@ class NavGoalArmPointer(Node):
         self.goal_active = False
         self.joint1_pos = None  # rad, from /joint_states
         self.vel_mode_on = False  # whether the arm is currently in velocity mode
-        self.homing = False  # returning joint1 to the base front after the goal ends
+        self.returning = False  # sending the arm to NAV_POSE after the goal ends
+        self.point_attempted = False  # tried to grab velocity mode for this goal
 
         latched = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
-        # True = arm idle / back to its normal pose; False = pointing or homing.
+        # True = arm idle / back to its normal pose; False = pointing or returning.
         # Latched so a late subscriber (nav_central) reads the current value.
         self.ready_pub = self.create_publisher(Bool, "/nav/arm_ready", latched)
         self.ready_pub.publish(Bool(data=True))
@@ -111,6 +116,9 @@ class NavGoalArmPointer(Node):
         )
         self.vel_client = self.create_client(
             MoveVelocity, XARM_MOVEVELOCITY_SERVICE, callback_group=cbg
+        )
+        self.move_joints_client = ActionClient(
+            self, MoveJoints, MOVE_JOINTS_ACTION, callback_group=cbg
         )
 
         for c, n in (
@@ -153,32 +161,73 @@ class NavGoalArmPointer(Node):
         req.speeds = [vel, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         self.vel_client.call_async(req)
 
+    # -- return to NAV_POSE (MoveIt) when the goal ends --
+
+    def _arm_ready(self):
+        """Mark the arm back to its normal pose so nav can finish. Idempotent."""
+        if self.returning:
+            self.returning = False
+            self.ready_pub.publish(Bool(data=True))
+
+    def _send_nav_pose(self):
+        """Plan + move to the named NAV_POSE via MoveIt. Non-blocking."""
+        if not self.move_joints_client.server_is_ready():
+            self.get_logger().warn(
+                "move_joints action server unavailable; skipping NAV_POSE"
+            )
+            self._arm_ready()  # don't block nav waiting for an arm that can't move
+            return
+        goal = MoveJoints.Goal()
+        goal.joint_names = NAV_POSE_NAMES
+        goal.joint_positions = NAV_POSE_RADS
+        goal.velocity = NAV_POSE_VELOCITY
+        self.move_joints_client.send_goal_async(goal).add_done_callback(
+            self._nav_pose_sent
+        )
+
+    def _nav_pose_sent(self, future):
+        gh = future.result()
+        if gh is None or not gh.accepted:
+            self.get_logger().warn("NAV_POSE goal rejected")
+            self._arm_ready()
+            return
+        gh.get_result_async().add_done_callback(lambda _f: self._nav_pose_done())
+
+    def _nav_pose_done(self):
+        self.get_logger().info("arm returned to NAV_POSE")
+        self._arm_ready()
+
     # -- control loop --
 
     def _control(self):
         # Activation / deactivation edges.
         if self.goal_active:
-            if not self.vel_mode_on and self._set_mode(JOINT_VELOCITY_MODE):
-                self.vel_mode_on = True
-                self.ready_pub.publish(Bool(data=False))  # busy: pointing
-            self.homing = False  # cancel any homing if a new goal arrives
-        elif self.vel_mode_on and not self.homing:
-            self.homing = True  # goal ended: return arm to base front before MoveIt
-
-        if not self.vel_mode_on or self.joint1_pos is None:
-            return
-
-        # Goal ended: drive joint1 back to the front, then hand the arm to MoveIt.
-        if self.homing:
-            vel = joint1_velocity(FRONT_TARGET, self.joint1_pos)
-            if vel == 0.0:  # at the front (within deadband)
+            # Try to take velocity control ONCE per goal. Retrying every tick
+            # fights ros2_control for /xarm/set_mode and storms "Failed to set
+            # xArm mode 4" when manipulation owns the arm. This assumes
+            # manipulation doesn't move the arm during navigation; real fix is
+            # node coordination (see _send_nav_pose / module TODO).
+            if not self.vel_mode_on and not self.point_attempted:
+                self.point_attempted = True
+                if self._set_mode(JOINT_VELOCITY_MODE):
+                    self.vel_mode_on = True
+                    self.ready_pub.publish(Bool(data=False))  # busy: pointing
+                else:
+                    self.get_logger().warn(
+                        "could not take velocity mode (arm busy?); not pointing this goal"
+                    )
+            self.returning = False  # a new goal preempts an in-flight NAV_POSE return
+        else:
+            self.point_attempted = False  # reset for the next goal
+            if self.vel_mode_on:
+                # Goal ended: stop pointing, hand to MoveIt, send arm to NAV_POSE.
                 self._send_joint1_vel(0.0)
                 self._set_mode(MOVEIT_MODE)
                 self.vel_mode_on = False
-                self.homing = False
-                self.ready_pub.publish(Bool(data=True))  # back to normal pose
-            else:
-                self._send_joint1_vel(vel)
+                self.returning = True
+                self._send_nav_pose()
+
+        if not self.vel_mode_on or self.joint1_pos is None:
             return
 
         if self.goal is None:

--- a/manipulation/packages/frida_motion_planning/scripts/nav_goal_arm_pointer.py
+++ b/manipulation/packages/frida_motion_planning/scripts/nav_goal_arm_pointer.py
@@ -31,6 +31,7 @@ from frida_constants.manipulation_constants import (
     XARM_SETMODE_SERVICE,
     XARM_SETSTATE_SERVICE,
     XARM_MOVEVELOCITY_SERVICE,
+    MANIPULATION_ARM_BUSY_TOPIC,
 )
 from frida_constants.xarm_configurations import NAV_POSE
 from frida_interfaces.action import MoveJoints
@@ -89,12 +90,22 @@ class NavGoalArmPointer(Node):
         self.vel_mode_on = False  # whether the arm is currently in velocity mode
         self.returning = False  # sending the arm to NAV_POSE after the goal ends
         self.point_attempted = False  # tried to grab velocity mode for this goal
+        self.arm_busy = False  # manipulation is executing a goal -> yield the arm
 
         latched = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
         # True = arm idle / back to its normal pose; False = pointing or returning.
         # Latched so a late subscriber (nav_central) reads the current value.
         self.ready_pub = self.create_publisher(Bool, "/nav/arm_ready", latched)
         self.ready_pub.publish(Bool(data=True))
+        # While manipulation owns the arm we must not touch /xarm/set_mode. Default
+        # False so we still point if motion_planning_server isn't publishing.
+        self.create_subscription(
+            Bool,
+            MANIPULATION_ARM_BUSY_TOPIC,
+            lambda m: setattr(self, "arm_busy", m.data),
+            latched,
+            callback_group=cbg,
+        )
         self.create_subscription(
             PoseStamped, "/nav/current_goal", self._goal_cb, latched, callback_group=cbg
         )
@@ -120,6 +131,11 @@ class NavGoalArmPointer(Node):
         self.move_joints_client = ActionClient(
             self, MoveJoints, MOVE_JOINTS_ACTION, callback_group=cbg
         )
+        # Each set_state on a mode switch otherwise resets the tool GPIO and opens
+        # the gripper. Disable that reset so the gripper stays put (same as follow_face).
+        self.tgpio_reset_client = self.create_client(
+            SetInt16, "/xarm/config_tgpio_reset_when_stop", callback_group=cbg
+        )
 
         for c, n in (
             (self.mode_client, "set_mode"),
@@ -128,6 +144,8 @@ class NavGoalArmPointer(Node):
         ):
             if not c.wait_for_service(timeout_sec=5.0):
                 self.get_logger().warn(f"xArm service {n} not available")
+
+        self._disable_gripper_reset()
 
         self.create_timer(CONTROL_PERIOD, self._control, callback_group=cbg)
         self.get_logger().info("nav_goal_arm_pointer ready (joint1 velocity control)")
@@ -143,6 +161,17 @@ class NavGoalArmPointer(Node):
             self.joint1_pos = msg.position[msg.name.index(JOINT1_NAME)]
 
     # -- xArm mode --
+
+    def _disable_gripper_reset(self):
+        """Tell the xArm driver not to reset tool GPIO (gripper) on state changes,
+        so our mode switches don't pop the gripper open. Best-effort, once."""
+        if not self.tgpio_reset_client.wait_for_service(timeout_sec=5.0):
+            self.get_logger().warn(
+                "config_tgpio_reset_when_stop unavailable; gripper may open on mode switches"
+            )
+            return
+        wait_for_future(self.tgpio_reset_client.call_async(SetInt16.Request(data=0)))
+        self.get_logger().info("TGPIO reset on stop disabled (gripper preserved)")
 
     def _set_mode(self, mode: int) -> bool:
         """Set xArm mode then state 0 (active). Blocking, best-effort."""
@@ -202,12 +231,20 @@ class NavGoalArmPointer(Node):
     def _control(self):
         # Activation / deactivation edges.
         if self.goal_active:
-            # Try to take velocity control ONCE per goal. Retrying every tick
-            # fights ros2_control for /xarm/set_mode and storms "Failed to set
-            # xArm mode 4" when manipulation owns the arm. This assumes
-            # manipulation doesn't move the arm during navigation; real fix is
-            # node coordination (see _send_nav_pose / module TODO).
-            if not self.vel_mode_on and not self.point_attempted:
+            self.returning = False  # a new goal preempts an in-flight NAV_POSE return
+            if self.arm_busy:
+                # Manipulation owns the arm: yield and never touch /xarm/set_mode.
+                # Its ensure_arm_ready reinits MoveIt mode for the motion; we just
+                # stop commanding. Relinquish so nav need not wait on us, and stay
+                # yielded for the rest of this goal (point_attempted stays set).
+                if self.vel_mode_on:
+                    self._send_joint1_vel(0.0)
+                    self.vel_mode_on = False
+                    self.ready_pub.publish(Bool(data=True))
+            elif not self.vel_mode_on and not self.point_attempted:
+                # Take velocity control ONCE per goal. Retrying every tick fights
+                # ros2_control for /xarm/set_mode and storms "Failed to set xArm
+                # mode 4"; the arm_busy gate keeps us off the arm during manipulation.
                 self.point_attempted = True
                 if self._set_mode(JOINT_VELOCITY_MODE):
                     self.vel_mode_on = True
@@ -216,7 +253,6 @@ class NavGoalArmPointer(Node):
                     self.get_logger().warn(
                         "could not take velocity mode (arm busy?); not pointing this goal"
                     )
-            self.returning = False  # a new goal preempts an in-flight NAV_POSE return
         else:
             self.point_attempted = False  # reset for the next goal
             if self.vel_mode_on:


### PR DESCRIPTION
Motion_planning_server (the sole xArm owner) publishes   /manipulation/arm_busy (latched Bool), True while a 
 MoveJoints/MoveToPose goal executes, cleared in finally.  - nav_goal_arm_pointer subscribes and yields while busy: it never 
 touches /xarm/set_mode, stops commanding, and relinquishes so nav doesn't wait on it. It only takes velocity mode when the arm is free. The handoff is clean because the existing manipulation_safeguard.ensure_arm_ready already reinits MoveIt mode before each manipulation move, so the pointer never has to  set MoveIt mode back itself.
Gripper:
On startup the pointer calls /xarm/config_tgpio_reset_when_stop  with 0, disabling the tool-GPIO reset on state changes so the gripper stays put across mode switches.


